### PR TITLE
chore: add go format check and update go version

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,6 +8,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch: 
 
 jobs:
 
@@ -17,9 +18,20 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.18
+        go-version: '1.20'
+        check-latest: true
+        cache: true
+
+    - name: Check Formatting
+      run: |
+        find . -name '*.go' -not -path './vendor/*' | xargs gofmt -d -s > gofmt.out
+        if [[ -s gofmt.out ]]; then
+          echo "The following files were found to have formatting deviations:"
+          cat gofmt.out
+          exit 1
+        fi
 
     - name: Build
       run: go build -v ./...

--- a/pkg/authenticate/doc.go
+++ b/pkg/authenticate/doc.go
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2023 Kavya Shukla <kavyuushukla@gmail.com>
 // SPDX-License-Identifier: GPL-2.0-only
 
-//Package authenticate is build to authenticate the API.
+// Package authenticate is build to authenticate the API.
 package authenticate

--- a/pkg/models/doc.go
+++ b/pkg/models/doc.go
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 // Package models is made to connect the database and to store the structs of
-//different data.
+// different data.
 package models

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -3,7 +3,6 @@
 
 package models
 
-//
 type License struct {
 	Shortname       string `json:"rf_shortname" gorm:"primary_key"`
 	Fullname        string `json:"rf_fullname"`


### PR DESCRIPTION
- go 1.18 has reached end of life, use go 1.20
- fix formatting errors

Signed-off-by: Avinal Kumar <avinal.xlvii@gmail.com>