### PR TITLE
fix(api): fixed error handeling in authentication middleware

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -221,7 +221,7 @@ func AuthenticationMiddleware() gin.HandlerFunc {
 			er := models.LicenseError{
 				Status:    http.StatusUnauthorized,
 				Message:   "User name not found",
-				Error:     err.Error(),
+				Error:     result.Error.Error(),
 				Path:      c.Request.URL.Path,
 				Timestamp: time.Now().Format(time.RFC3339),
 			}
@@ -236,7 +236,7 @@ func AuthenticationMiddleware() gin.HandlerFunc {
 			er := models.LicenseError{
 				Status:    http.StatusUnauthorized,
 				Message:   "Incorrect password",
-				Error:     err.Error(),
+				Error:     "Password does not match",
 				Path:      c.Request.URL.Path,
 				Timestamp: time.Now().Format(time.RFC3339),
 			}


### PR DESCRIPTION
## Description
This PR solves the nil pointer dereference issue(internal server error) highlighted in #28 
## Changes
In the authentication middleware, the `err` variable is used inconsistently. Please refer to the snippet below- 
https://github.com/fossology/LicenseDb/blob/aa42310676d7cf70a3319d11624bc74dc29372b8/pkg/auth/auth.go#L194-L207
Here the `err` variable is appropriately used to capture potential errors during the base64 decoding process, but it is incorrectly used further in the code. 
https://github.com/fossology/LicenseDb/blob/aa42310676d7cf70a3319d11624bc74dc29372b8/pkg/auth/auth.go#L219-L247
At line 224, `err.Error()` references to decoding errors but it should be referencing to the errors occurring during GORM db querying process happening at line 219. Hence it is replaced by `result.Error.Error()` to deliever GORM specific errors.

Furthermore, line 239 is also modified to give 'Password does not match' error rather than `err.Error()`.

Fixes #28 
CC @GMishx 