### PR TITLE
fix(obligation): fix FirstOrCreate in obligation creation

### DIFF
--- a/pkg/api/licenses.go
+++ b/pkg/api/licenses.go
@@ -279,9 +279,10 @@ func CreateLicense(c *gin.Context) {
 		Risk:            input.Risk,
 	}
 
-	result := db.DB.FirstOrCreate(&license)
+	result := db.DB.
+		Where(&models.LicenseDB{Shortname: license.Shortname}).
+		FirstOrCreate(&license)
 	if result.RowsAffected == 0 {
-
 		er := models.LicenseError{
 			Status:    http.StatusConflict,
 			Message:   "can not create license with same shortname",

--- a/pkg/api/obligations.go
+++ b/pkg/api/obligations.go
@@ -157,15 +157,17 @@ func CreateObligation(c *gin.Context) {
 		Active:         input.Active,
 	}
 
-	result := db.DB.FirstOrCreate(&obligation)
+	result := db.DB.
+		Where(&models.Obligation{Topic: obligation.Topic}).
+		Or(&models.Obligation{Md5: obligation.Md5}).
+		FirstOrCreate(&obligation)
 
-	fmt.Print(obligation)
 	if result.RowsAffected == 0 {
-
 		er := models.LicenseError{
-			Status:    http.StatusConflict,
-			Message:   "can not create obligation with same MD5",
-			Error:     fmt.Sprintf("Error: Obligation with MD5 '%s' already exists", obligation.Md5),
+			Status:  http.StatusConflict,
+			Message: "can not create obligation with same MD5",
+			Error: fmt.Sprintf("Error: Obligation with topic '%s' or MD5 '%s' already exists",
+				obligation.Topic, obligation.Md5),
 			Path:      c.Request.URL.Path,
 			Timestamp: time.Now().Format(time.RFC3339),
 		}


### PR DESCRIPTION
Fix the `FirstOrCreate()` call in obligation creation endpoint by adding the `Where` clause to check topic and md5. This actually checks if the obligation is a duplicate instead of simply taking the first value.