### PR TITLE
fix(lint): Fixed golang linting errors

### DIFF
--- a/cmd/laas/main.go
+++ b/cmd/laas/main.go
@@ -71,11 +71,13 @@ func main() {
 		log.Fatalf("Failed to automigrate database: %v", err)
 	}
 
-	if *populatedb == true {
+	if *populatedb {
 		db.Populatedb(*datafile)
 	}
 
 	r := api.Router()
 
-	r.Run()
+	if err := r.Run(); err != nil {
+		log.Fatalf("Error while running the server: %v", err)
+	}
 }

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -64,7 +64,10 @@ func TestGetLicense(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var res models.LicenseResponse
-	json.Unmarshal(w.Body.Bytes(), &res)
+	if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+		t.Errorf("Error unmarshalling JSON: %v", err)
+		return
+	}
 
 	assert.Equal(t, expectLicense, res.Data[0])
 
@@ -83,12 +86,12 @@ func TestCreateLicense(t *testing.T) {
 	}
 	w := makeRequest("POST", "/api/licenses", License, true)
 	assert.Equal(t, http.StatusCreated, w.Code)
-	type response struct {
-		Data models.LicenseDB `json:"data"`
-	}
 
 	var res models.LicenseResponse
-	json.Unmarshal(w.Body.Bytes(), &res)
+	if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+		t.Errorf("Error unmarshalling JSON: %v", err)
+		return
+	}
 
 	assert.Equal(t, License, res.Data[0])
 
@@ -114,7 +117,10 @@ func TestUpdateLicense(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var res models.LicenseResponse
-	json.Unmarshal(w.Body.Bytes(), &res)
+	if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+		t.Errorf("Error unmarshalling JSON: %v", err)
+		return
+	}
 
 	assert.Equal(t, expectedLicense, res.Data[0])
 
@@ -142,7 +148,10 @@ func TestSearchInLicense(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var res models.LicenseResponse
-	json.Unmarshal(w.Body.Bytes(), &res)
+	if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+		t.Errorf("Error unmarshalling JSON: %v", err)
+		return
+	}
 
 	assert.Equal(t, expectLicense, res.Data[0])
 
@@ -186,38 +195,49 @@ func TestSearchInLicense2(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var res models.LicenseResponse
-	json.Unmarshal(w.Body.Bytes(), &res)
+	if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+		t.Errorf("Error unmarshalling JSON: %v", err)
+		return
+	}
 
 	assert.Equal(t, expectLicense, res.Data)
 }
 
 func TestGetUser(t *testing.T) {
+	password := "fossy"
 	expectUser := models.User{
 		Username:     "fossy",
-		Userpassword: "fossy",
+		Userpassword: &password,
 		Userlevel:    "admin",
 	}
 	w := makeRequest("GET", "/api/user/1", nil, false)
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var res models.UserResponse
-	json.Unmarshal(w.Body.Bytes(), &res)
+	if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+		t.Errorf("Error unmarshalling JSON: %v", err)
+		return
+	}
 
 	assert.Equal(t, expectUser, res.Data[0])
 
 }
 
 func TestCreateUser(t *testing.T) {
+	password := "abc123"
 	user := models.User{
 		Username:     "general_user",
-		Userpassword: "abc123",
+		Userpassword: &password,
 		Userlevel:    "participant",
 	}
 	w := makeRequest("POST", "/api/user", user, true)
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var res models.UserResponse
-	json.Unmarshal(w.Body.Bytes(), &res)
+	if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+		t.Errorf("Error unmarshalling JSON: %v", err)
+		return
+	}
 
 	assert.Equal(t, user, res.Data[0])
 }

--- a/pkg/api/licenses.go
+++ b/pkg/api/licenses.go
@@ -363,7 +363,7 @@ func UpdateLicense(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, er)
 		return
 	}
-	if update.Text != "" && oldlicense.TextUpdatable == false && oldlicense.Text != update.Text {
+	if update.Text != "" && !oldlicense.TextUpdatable && oldlicense.Text != update.Text {
 		er := models.LicenseError{
 			Status:    http.StatusBadRequest,
 			Message:   "Text is not updatable",

--- a/pkg/api/obligations.go
+++ b/pkg/api/obligations.go
@@ -253,7 +253,7 @@ func UpdateObligation(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, er)
 		return
 	}
-	if oldobligation.TextUpdatable == false && update.Text != "" && update.Text != oldobligation.Text {
+	if !oldobligation.TextUpdatable && update.Text != "" && update.Text != oldobligation.Text {
 		er := models.LicenseError{
 			Status:    http.StatusBadRequest,
 			Message:   "Can not update obligation text",


### PR DESCRIPTION
## Description

This PR fixes all the errors and warnings cached by `golangci-lint` , hence making the codebase clean and ready to deploy golang static checks and linting action as mentioned in #36 

![image](https://github.com/fossology/LicenseDb/assets/119073504/b6851c1c-d709-48c8-ba69-7193111169e8)

closes #37 
merge before #36 

CC @GMishx 
