### PR TITLE
Make port in swagger docs configurable

### DIFF
--- a/cmd/laas/docs/docs.go
+++ b/cmd/laas/docs/docs.go
@@ -2028,7 +2028,7 @@ const docTemplate = `{
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "0.0.9",
-	Host:             "localhost:8080",
+	Host:             "",
 	BasePath:         "/api/v1",
 	Schemes:          []string{},
 	Title:            "laas (License as a Service) API",

--- a/cmd/laas/docs/swagger.json
+++ b/cmd/laas/docs/swagger.json
@@ -14,7 +14,6 @@
         },
         "version": "0.0.9"
     },
-    "host": "localhost:8080",
     "basePath": "/api/v1",
     "paths": {
         "/audits": {

--- a/cmd/laas/docs/swagger.yaml
+++ b/cmd/laas/docs/swagger.yaml
@@ -526,7 +526,6 @@ definitions:
         example: 200
         type: integer
     type: object
-host: localhost:8080
 info:
   contact:
     email: fossology@fossology.org

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -7,13 +7,16 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
 
+	"github.com/fossology/LicenseDb/cmd/laas/docs"
 	"github.com/fossology/LicenseDb/pkg/auth"
 	"github.com/fossology/LicenseDb/pkg/db"
 	"github.com/fossology/LicenseDb/pkg/middleware"
@@ -33,14 +36,23 @@ import (
 //	@license.name				GPL-2.0-only
 //	@license.url				https://github.com/fossology/LicenseDb/blob/main/LICENSE
 //
-//	@host						localhost:8080
 //	@BasePath					/api/v1
 //
 //	@securityDefinitions.apikey	ApiKeyAuth
 //	@in							header
 //	@name						Authorization
 //	@description				Token from /login endpoint
+
+const DEFAULT_PORT = "8080"
+
 func Router() *gin.Engine {
+
+	port := os.Getenv("PORT")
+	if len(port) == 0 {
+		port = DEFAULT_PORT
+	}
+	docs.SwaggerInfo.Host = fmt.Sprintf("localhost:%s", port)
+
 	// r is a default instance of gin engine
 	r := gin.Default()
 


### PR DESCRIPTION
This PR makes port in swagger docs configurable. Fetches the env variable "PORT" and assigns it to the swagger config variable "Host" on start. 