### PR TITLE
feat(obligation_import): Add functionality to import obligations via …

### DIFF
--- a/cmd/laas/docs/docs.go
+++ b/cmd/laas/docs/docs.go
@@ -880,6 +880,71 @@ const docTemplate = `{
                 }
             }
         },
+        "/obligations/import": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Import obligations by uploading a json file",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Obligations"
+                ],
+                "summary": "Import obligations by uploading a json file",
+                "operationId": "ImportObligations",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "obligations json file list",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/models.ImportObligationsResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/models.ObligationImportStatus"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "input file must be present",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    }
+                }
+            }
+        },
         "/obligations/{topic}": {
             "get": {
                 "description": "Get an active based on given topic",
@@ -1356,6 +1421,20 @@ const docTemplate = `{
                 }
             }
         },
+        "models.ImportObligationsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "can be of type models.LicenseError or models.ObligationImportStatus",
+                    "type": "array",
+                    "items": {}
+                },
+                "status": {
+                    "type": "integer",
+                    "example": 200
+                }
+            }
+        },
         "models.LicenseDB": {
             "type": "object",
             "required": [
@@ -1717,6 +1796,31 @@ const docTemplate = `{
                         "right"
                     ],
                     "example": "risk"
+                }
+            }
+        },
+        "models.ObligationId": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "example": 31
+                },
+                "topic": {
+                    "type": "string",
+                    "example": "copyleft"
+                }
+            }
+        },
+        "models.ObligationImportStatus": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.ObligationId"
+                },
+                "status": {
+                    "type": "integer",
+                    "example": 200
                 }
             }
         },

--- a/cmd/laas/docs/swagger.json
+++ b/cmd/laas/docs/swagger.json
@@ -873,6 +873,71 @@
                 }
             }
         },
+        "/obligations/import": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Import obligations by uploading a json file",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Obligations"
+                ],
+                "summary": "Import obligations by uploading a json file",
+                "operationId": "ImportObligations",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "obligations json file list",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/models.ImportObligationsResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/models.ObligationImportStatus"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "input file must be present",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    }
+                }
+            }
+        },
         "/obligations/{topic}": {
             "get": {
                 "description": "Get an active based on given topic",
@@ -1349,6 +1414,20 @@
                 }
             }
         },
+        "models.ImportObligationsResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "can be of type models.LicenseError or models.ObligationImportStatus",
+                    "type": "array",
+                    "items": {}
+                },
+                "status": {
+                    "type": "integer",
+                    "example": 200
+                }
+            }
+        },
         "models.LicenseDB": {
             "type": "object",
             "required": [
@@ -1710,6 +1789,31 @@
                         "right"
                     ],
                     "example": "risk"
+                }
+            }
+        },
+        "models.ObligationId": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "example": 31
+                },
+                "topic": {
+                    "type": "string",
+                    "example": "copyleft"
+                }
+            }
+        },
+        "models.ObligationImportStatus": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.ObligationId"
+                },
+                "status": {
+                    "type": "integer",
+                    "example": 200
                 }
             }
         },

--- a/cmd/laas/docs/swagger.yaml
+++ b/cmd/laas/docs/swagger.yaml
@@ -62,6 +62,16 @@ definitions:
         example: 200
         type: integer
     type: object
+  models.ImportObligationsResponse:
+    properties:
+      data:
+        description: can be of type models.LicenseError or models.ObligationImportStatus
+        items: {}
+        type: array
+      status:
+        example: 200
+        type: integer
+    type: object
   models.LicenseDB:
     properties:
       external_ref:
@@ -317,6 +327,23 @@ definitions:
         - right
         example: risk
         type: string
+    type: object
+  models.ObligationId:
+    properties:
+      id:
+        example: 31
+        type: integer
+      topic:
+        example: copyleft
+        type: string
+    type: object
+  models.ObligationImportStatus:
+    properties:
+      data:
+        $ref: '#/definitions/models.ObligationId'
+      status:
+        example: 200
+        type: integer
     type: object
   models.ObligationMapResponse:
     properties:
@@ -1229,6 +1256,45 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Fetches audits corresponding to an obligation
+      tags:
+      - Obligations
+  /obligations/import:
+    post:
+      consumes:
+      - multipart/form-data
+      description: Import obligations by uploading a json file
+      operationId: ImportObligations
+      parameters:
+      - description: obligations json file list
+        in: formData
+        name: file
+        required: true
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/models.ImportObligationsResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/models.ObligationImportStatus'
+                  type: array
+              type: object
+        "400":
+          description: input file must be present
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+      security:
+      - ApiKeyAuth: []
+      summary: Import obligations by uploading a json file
       tags:
       - Obligations
   /search:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -121,6 +121,7 @@ func Router() *gin.Engine {
 		obligations := authorizedv1.Group("/obligations")
 		{
 			obligations.POST("", CreateObligation)
+			obligations.POST("import", ImportObligations)
 			obligations.PATCH(":topic", UpdateObligation)
 			obligations.DELETE(":topic", DeleteObligation)
 		}

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -325,3 +325,39 @@ type ObligationMapResponse struct {
 	Data   []ObligationMapUser `json:"data"`
 	Meta   PaginationMeta      `json:"paginationmeta"`
 }
+
+// ObligationImportRequest represents the request body structure for import obligation
+type ObligationImportRequest struct {
+	ObligationFile string `form:"file"`
+}
+
+// ObligationImport represents an obligation record in the import json file.
+type ObligationImport struct {
+	Topic          string   `json:"topic" example:"copyleft" validate:"required"` // binding:"required" tag cannot be used as is works only for request body
+	Type           string   `json:"type" enums:"obligation,restriction,risk,right" validate:"required"`
+	Text           string   `json:"text" example:"Source code be made available when distributing the software." validate:"required"`
+	Classification string   `json:"classification" enums:"green,white,yellow,red" validate:"required"`
+	Modifications  bool     `json:"modifications" validate:"required"`
+	Comment        string   `json:"comment" example:"This is a comment." validate:"required"`
+	Active         bool     `json:"active" validate:"required"`
+	TextUpdatable  bool     `json:"text_updatable" validate:"required"`
+	Shortnames     []string `json:"shortnames" example:"GPL-2.0-only,GPL-2.0-or-later" validate:"required"`
+}
+
+// ObligationId is the id of successfully imported obligation
+type ObligationId struct {
+	Id    int64  `json:"id" example:"31"`
+	Topic string `json:"topic" example:"copyleft"`
+}
+
+// ObligationImportStatus is the status of obligation records successfully inserted in the database during import
+type ObligationImportStatus struct {
+	Status int          `json:"status" example:"200"`
+	Data   ObligationId `json:"data"`
+}
+
+// ImportObligationsResponse is the response structure for import obligation response
+type ImportObligationsResponse struct {
+	Status int           `json:"status" example:"200"`
+	Data   []interface{} `json:"data"` // can be of type models.LicenseError or models.ObligationImportStatus
+}


### PR DESCRIPTION
Add functionality to import obligations via a json file
JSON file format example: 
```
[
    {
        "topic": "Provide Copyright Notices",
        "type": "obligation",
        "text": "Text 2",
        "classification": "green",
        "modifications": true,
        "comment": "",
        "shortnames": ["LGPL-3.0-or-later","QPL-1.0","GPL-1.0-only","GPL-1.0-or-later"],
        "active": true,
        "text_updatable": true
    },
    {
        "topic": "provide license upstream",
        "type": "obligation",
        "text": "Text",
        "modifications": false,
        "comment": "",
        "shortnames": ["LGPL-2.1-only"],
        "active": true,
        "text_updatable": true
    }
]
```