### PR TITLE
fix(patch_obligation): Fix patch request bugs in obligation

### DIFF
--- a/cmd/laas/docs/docs.go
+++ b/cmd/laas/docs/docs.go
@@ -848,7 +848,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.ObligationInput"
+                            "$ref": "#/definitions/models.ObligationPOSTRequestJSONSchema"
                         }
                     }
                 ],
@@ -989,7 +989,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.UpdateObligation"
+                            "$ref": "#/definitions/models.ObligationPATCHRequestJSONSchema"
                         }
                     }
                 ],
@@ -1682,89 +1682,27 @@ const docTemplate = `{
                         "white",
                         "yellow",
                         "red"
-                    ]
+                    ],
+                    "example": "green"
                 },
                 "comment": {
-                    "type": "string",
-                    "example": "This is a comment."
+                    "type": "string"
                 },
                 "id": {
                     "type": "integer",
                     "example": 147
                 },
-                "md5": {
-                    "type": "string",
-                    "example": "deadbeef"
-                },
                 "modifications": {
-                    "type": "boolean"
-                },
-                "text": {
-                    "type": "string",
-                    "example": "Source code be made available when distributing the software."
-                },
-                "text_updatable": {
-                    "type": "boolean"
-                },
-                "topic": {
-                    "type": "string",
-                    "example": "copyleft"
-                },
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "obligation",
-                        "restriction",
-                        "risk",
-                        "right"
-                    ]
-                }
-            }
-        },
-        "models.ObligationInput": {
-            "type": "object",
-            "required": [
-                "text",
-                "topic",
-                "type"
-            ],
-            "properties": {
-                "active": {
                     "type": "boolean",
                     "example": true
                 },
-                "classification": {
-                    "type": "string",
-                    "enum": [
-                        "green",
-                        "white",
-                        "yellow",
-                        "red"
-                    ]
-                },
-                "comment": {
-                    "type": "string",
-                    "example": "This is a comment."
-                },
-                "modifications": {
-                    "type": "boolean"
-                },
-                "shortnames": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "example": [
-                        "GPL-2.0-only",
-                        "GPL-2.0-or-later"
-                    ]
-                },
                 "text": {
                     "type": "string",
                     "example": "Source code be made available when distributing the software."
                 },
                 "text_updatable": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "example": true
                 },
                 "topic": {
                     "type": "string",
@@ -1777,7 +1715,8 @@ const docTemplate = `{
                         "restriction",
                         "risk",
                         "right"
-                    ]
+                    ],
+                    "example": "risk"
                 }
             }
         },
@@ -1815,6 +1754,108 @@ const docTemplate = `{
                 "topic": {
                     "type": "string",
                     "example": "copyleft"
+                }
+            }
+        },
+        "models.ObligationPATCHRequestJSONSchema": {
+            "type": "object",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "classification": {
+                    "type": "string",
+                    "enum": [
+                        "green",
+                        "white",
+                        "yellow",
+                        "red"
+                    ]
+                },
+                "comment": {
+                    "type": "string",
+                    "example": "This is a comment."
+                },
+                "modifications": {
+                    "type": "boolean"
+                },
+                "text": {
+                    "type": "string",
+                    "example": "Source code be made available when distributing the software."
+                },
+                "text_updatable": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "obligation",
+                        "restriction",
+                        "risk",
+                        "right"
+                    ]
+                }
+            }
+        },
+        "models.ObligationPOSTRequestJSONSchema": {
+            "type": "object",
+            "required": [
+                "active",
+                "classification",
+                "comment",
+                "modifications",
+                "shortnames",
+                "text",
+                "topic",
+                "type"
+            ],
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "classification": {
+                    "type": "string",
+                    "enum": [
+                        "green",
+                        "white",
+                        "yellow",
+                        "red"
+                    ]
+                },
+                "comment": {
+                    "type": "string"
+                },
+                "modifications": {
+                    "type": "boolean"
+                },
+                "shortnames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "GPL-2.0-only",
+                        "GPL-2.0-or-later"
+                    ]
+                },
+                "text": {
+                    "type": "string",
+                    "example": "Source code be made available when distributing the software."
+                },
+                "topic": {
+                    "type": "string",
+                    "example": "copyleft"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "obligation",
+                        "restriction",
+                        "risk",
+                        "right"
+                    ]
                 }
             }
         },
@@ -1886,51 +1927,6 @@ const docTemplate = `{
                 "search_term": {
                     "type": "string",
                     "example": "MIT License"
-                }
-            }
-        },
-        "models.UpdateObligation": {
-            "type": "object",
-            "properties": {
-                "active": {
-                    "type": "boolean",
-                    "example": true
-                },
-                "classification": {
-                    "type": "string",
-                    "enum": [
-                        "green",
-                        "white",
-                        "yellow",
-                        "red"
-                    ]
-                },
-                "comment": {
-                    "type": "string",
-                    "example": "This is a comment."
-                },
-                "modifications": {
-                    "type": "boolean"
-                },
-                "text": {
-                    "type": "string",
-                    "example": "Source code be made available when distributing the software."
-                },
-                "text_updatable": {
-                    "type": "boolean"
-                },
-                "topic": {
-                    "type": "string",
-                    "example": "copyleft"
-                },
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "obligation",
-                        "restriction",
-                        "risk",
-                        "right"
-                    ]
                 }
             }
         },

--- a/cmd/laas/docs/swagger.json
+++ b/cmd/laas/docs/swagger.json
@@ -841,7 +841,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.ObligationInput"
+                            "$ref": "#/definitions/models.ObligationPOSTRequestJSONSchema"
                         }
                     }
                 ],
@@ -982,7 +982,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.UpdateObligation"
+                            "$ref": "#/definitions/models.ObligationPATCHRequestJSONSchema"
                         }
                     }
                 ],
@@ -1675,89 +1675,27 @@
                         "white",
                         "yellow",
                         "red"
-                    ]
+                    ],
+                    "example": "green"
                 },
                 "comment": {
-                    "type": "string",
-                    "example": "This is a comment."
+                    "type": "string"
                 },
                 "id": {
                     "type": "integer",
                     "example": 147
                 },
-                "md5": {
-                    "type": "string",
-                    "example": "deadbeef"
-                },
                 "modifications": {
-                    "type": "boolean"
-                },
-                "text": {
-                    "type": "string",
-                    "example": "Source code be made available when distributing the software."
-                },
-                "text_updatable": {
-                    "type": "boolean"
-                },
-                "topic": {
-                    "type": "string",
-                    "example": "copyleft"
-                },
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "obligation",
-                        "restriction",
-                        "risk",
-                        "right"
-                    ]
-                }
-            }
-        },
-        "models.ObligationInput": {
-            "type": "object",
-            "required": [
-                "text",
-                "topic",
-                "type"
-            ],
-            "properties": {
-                "active": {
                     "type": "boolean",
                     "example": true
                 },
-                "classification": {
-                    "type": "string",
-                    "enum": [
-                        "green",
-                        "white",
-                        "yellow",
-                        "red"
-                    ]
-                },
-                "comment": {
-                    "type": "string",
-                    "example": "This is a comment."
-                },
-                "modifications": {
-                    "type": "boolean"
-                },
-                "shortnames": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "example": [
-                        "GPL-2.0-only",
-                        "GPL-2.0-or-later"
-                    ]
-                },
                 "text": {
                     "type": "string",
                     "example": "Source code be made available when distributing the software."
                 },
                 "text_updatable": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "example": true
                 },
                 "topic": {
                     "type": "string",
@@ -1770,7 +1708,8 @@
                         "restriction",
                         "risk",
                         "right"
-                    ]
+                    ],
+                    "example": "risk"
                 }
             }
         },
@@ -1808,6 +1747,108 @@
                 "topic": {
                     "type": "string",
                     "example": "copyleft"
+                }
+            }
+        },
+        "models.ObligationPATCHRequestJSONSchema": {
+            "type": "object",
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "classification": {
+                    "type": "string",
+                    "enum": [
+                        "green",
+                        "white",
+                        "yellow",
+                        "red"
+                    ]
+                },
+                "comment": {
+                    "type": "string",
+                    "example": "This is a comment."
+                },
+                "modifications": {
+                    "type": "boolean"
+                },
+                "text": {
+                    "type": "string",
+                    "example": "Source code be made available when distributing the software."
+                },
+                "text_updatable": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "obligation",
+                        "restriction",
+                        "risk",
+                        "right"
+                    ]
+                }
+            }
+        },
+        "models.ObligationPOSTRequestJSONSchema": {
+            "type": "object",
+            "required": [
+                "active",
+                "classification",
+                "comment",
+                "modifications",
+                "shortnames",
+                "text",
+                "topic",
+                "type"
+            ],
+            "properties": {
+                "active": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "classification": {
+                    "type": "string",
+                    "enum": [
+                        "green",
+                        "white",
+                        "yellow",
+                        "red"
+                    ]
+                },
+                "comment": {
+                    "type": "string"
+                },
+                "modifications": {
+                    "type": "boolean"
+                },
+                "shortnames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "example": [
+                        "GPL-2.0-only",
+                        "GPL-2.0-or-later"
+                    ]
+                },
+                "text": {
+                    "type": "string",
+                    "example": "Source code be made available when distributing the software."
+                },
+                "topic": {
+                    "type": "string",
+                    "example": "copyleft"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "obligation",
+                        "restriction",
+                        "risk",
+                        "right"
+                    ]
                 }
             }
         },
@@ -1879,51 +1920,6 @@
                 "search_term": {
                     "type": "string",
                     "example": "MIT License"
-                }
-            }
-        },
-        "models.UpdateObligation": {
-            "type": "object",
-            "properties": {
-                "active": {
-                    "type": "boolean",
-                    "example": true
-                },
-                "classification": {
-                    "type": "string",
-                    "enum": [
-                        "green",
-                        "white",
-                        "yellow",
-                        "red"
-                    ]
-                },
-                "comment": {
-                    "type": "string",
-                    "example": "This is a comment."
-                },
-                "modifications": {
-                    "type": "boolean"
-                },
-                "text": {
-                    "type": "string",
-                    "example": "Source code be made available when distributing the software."
-                },
-                "text_updatable": {
-                    "type": "boolean"
-                },
-                "topic": {
-                    "type": "string",
-                    "example": "copyleft"
-                },
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "obligation",
-                        "restriction",
-                        "risk",
-                        "right"
-                    ]
                 }
             }
         },

--- a/cmd/laas/docs/swagger.yaml
+++ b/cmd/laas/docs/swagger.yaml
@@ -290,62 +290,21 @@ definitions:
         - white
         - yellow
         - red
+        example: green
         type: string
       comment:
-        example: This is a comment.
         type: string
       id:
         example: 147
         type: integer
-      md5:
-        example: deadbeef
-        type: string
       modifications:
-        type: boolean
-      text:
-        example: Source code be made available when distributing the software.
-        type: string
-      text_updatable:
-        type: boolean
-      topic:
-        example: copyleft
-        type: string
-      type:
-        enum:
-        - obligation
-        - restriction
-        - risk
-        - right
-        type: string
-    type: object
-  models.ObligationInput:
-    properties:
-      active:
         example: true
         type: boolean
-      classification:
-        enum:
-        - green
-        - white
-        - yellow
-        - red
-        type: string
-      comment:
-        example: This is a comment.
-        type: string
-      modifications:
-        type: boolean
-      shortnames:
-        example:
-        - GPL-2.0-only
-        - GPL-2.0-or-later
-        items:
-          type: string
-        type: array
       text:
         example: Source code be made available when distributing the software.
         type: string
       text_updatable:
+        example: true
         type: boolean
       topic:
         example: copyleft
@@ -356,11 +315,8 @@ definitions:
         - restriction
         - risk
         - right
+        example: risk
         type: string
-    required:
-    - text
-    - topic
-    - type
     type: object
   models.ObligationMapResponse:
     properties:
@@ -386,6 +342,82 @@ definitions:
       topic:
         example: copyleft
         type: string
+    type: object
+  models.ObligationPATCHRequestJSONSchema:
+    properties:
+      active:
+        example: true
+        type: boolean
+      classification:
+        enum:
+        - green
+        - white
+        - yellow
+        - red
+        type: string
+      comment:
+        example: This is a comment.
+        type: string
+      modifications:
+        type: boolean
+      text:
+        example: Source code be made available when distributing the software.
+        type: string
+      text_updatable:
+        type: boolean
+      type:
+        enum:
+        - obligation
+        - restriction
+        - risk
+        - right
+        type: string
+    type: object
+  models.ObligationPOSTRequestJSONSchema:
+    properties:
+      active:
+        example: true
+        type: boolean
+      classification:
+        enum:
+        - green
+        - white
+        - yellow
+        - red
+        type: string
+      comment:
+        type: string
+      modifications:
+        type: boolean
+      shortnames:
+        example:
+        - GPL-2.0-only
+        - GPL-2.0-or-later
+        items:
+          type: string
+        type: array
+      text:
+        example: Source code be made available when distributing the software.
+        type: string
+      topic:
+        example: copyleft
+        type: string
+      type:
+        enum:
+        - obligation
+        - restriction
+        - risk
+        - right
+        type: string
+    required:
+    - active
+    - classification
+    - comment
+    - modifications
+    - shortnames
+    - text
+    - topic
+    - type
     type: object
   models.ObligationResponse:
     properties:
@@ -436,39 +468,6 @@ definitions:
     required:
     - field
     - search_term
-    type: object
-  models.UpdateObligation:
-    properties:
-      active:
-        example: true
-        type: boolean
-      classification:
-        enum:
-        - green
-        - white
-        - yellow
-        - red
-        type: string
-      comment:
-        example: This is a comment.
-        type: string
-      modifications:
-        type: boolean
-      text:
-        example: Source code be made available when distributing the software.
-        type: string
-      text_updatable:
-        type: boolean
-      topic:
-        example: copyleft
-        type: string
-      type:
-        enum:
-        - obligation
-        - restriction
-        - risk
-        - right
-        type: string
     type: object
   models.User:
     properties:
@@ -1075,7 +1074,7 @@ paths:
         name: obligation
         required: true
         schema:
-          $ref: '#/definitions/models.ObligationInput'
+          $ref: '#/definitions/models.ObligationPOSTRequestJSONSchema'
       produces:
       - application/json
       responses:
@@ -1167,7 +1166,7 @@ paths:
         name: obligation
         required: true
         schema:
-          $ref: '#/definitions/models.UpdateObligation'
+          $ref: '#/definitions/models.ObligationPATCHRequestJSONSchema'
       produces:
       - application/json
       responses:

--- a/pkg/models/optional_data_types.go
+++ b/pkg/models/optional_data_types.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2023 Siemens AG
+// SPDX-FileContributor: Dearsh Oberoi <oberoidearsh@gmail.com>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+package models
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// When we unmarshal json, the undefined keys take zero values in structs. So, there
+// is no way to differentiate between an undefined value and an actual zero value when
+// it is passed. OptionalData is a generic for differentiating between undefined and
+// zero valued keys in json.
+type OptionalData[T any] struct {
+	// This is set to true if corresponding key is present in json object
+	IsDefined bool
+	rawJson   json.RawMessage
+	Value     T
+}
+
+func (v *OptionalData[T]) UnmarshalJSON(data []byte) error {
+	v.rawJson = append((v.rawJson)[0:0], data...)
+	if len(v.rawJson) != 0 {
+		var x *T
+		if err := json.Unmarshal(data, &x); err != nil {
+			return err
+		}
+		if x == nil {
+			return errors.New("field value cannot be null")
+		}
+		v.Value = *x
+		v.IsDefined = true
+	}
+	return nil
+}

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -246,42 +246,39 @@ type AuditResponse struct {
 
 // Obligation represents an obligation record in the database.
 type Obligation struct {
-	Id             int64  `json:"id" gorm:"primary_key" example:"147"`
-	Topic          string `json:"topic" gorm:"unique" example:"copyleft"`
-	Type           string `json:"type" enums:"obligation,restriction,risk,right"`
+	Id             int64  `gorm:"primary_key" json:"id" example:"147"`
+	Topic          string `gorm:"unique" json:"topic" example:"copyleft"`
+	Type           string `json:"type" enums:"obligation,restriction,risk,right" example:"risk"`
 	Text           string `json:"text" example:"Source code be made available when distributing the software."`
-	Classification string `json:"classification" enums:"green,white,yellow,red"`
-	Modifications  bool   `json:"modifications"`
-	Comment        string `json:"comment" example:"This is a comment."`
-	Active         bool   `json:"active" gorm:"column:active"`
-	TextUpdatable  bool   `json:"text_updatable"`
-	Md5            string `json:"md5" gorm:"unique" example:"deadbeef"`
+	Classification string `json:"classification" enums:"green,white,yellow,red" example:"green"`
+	Modifications  bool   `json:"modifications" example:"true"`
+	Comment        string `json:"comment"`
+	Active         bool   `json:"active"`
+	TextUpdatable  bool   `json:"text_updatable" example:"true"`
+	Md5            string `gorm:"unique" json:"-"`
 }
 
-// ObligationInput represents the input format for creating a new obligation.
-type ObligationInput struct {
+// ObligationPOSTRequestJSONSchema represents the data format of POST request for obligation
+type ObligationPOSTRequestJSONSchema struct {
 	Topic          string   `json:"topic" binding:"required" example:"copyleft"`
-	Type           string   `json:"type" binding:"required" enums:"obligation,restriction,risk,right"`
+	Type           string   `json:"type" enums:"obligation,restriction,risk,right" binding:"required"`
 	Text           string   `json:"text" binding:"required" example:"Source code be made available when distributing the software."`
-	Classification string   `json:"classification" enums:"green,white,yellow,red"`
-	Modifications  bool     `json:"modifications"`
-	Comment        string   `json:"comment" example:"This is a comment."`
-	Active         bool     `json:"active" example:"true"`
-	TextUpdatable  bool     `json:"text_updatable"`
-	Shortnames     []string `json:"shortnames" example:"GPL-2.0-only,GPL-2.0-or-later"`
+	Classification string   `json:"classification" enums:"green,white,yellow,red" binding:"required"`
+	Modifications  bool     `json:"modifications" binding:"required"`
+	Comment        string   `json:"comment" binding:"required"`
+	Shortnames     []string `json:"shortnames" binding:"required" example:"GPL-2.0-only,GPL-2.0-or-later"`
+	Active         bool     `json:"active" binding:"required" example:"true"`
 }
 
-// UpdateObligation represents the input format for updating an existing obligation.
-type UpdateObligation struct {
-	Topic          string `json:"topic" example:"copyleft"`
-	Type           string `json:"type" enums:"obligation,restriction,risk,right"`
-	Text           string `json:"text" example:"Source code be made available when distributing the software."`
-	Classification string `json:"classification" enums:"green,white,yellow,red"`
-	Modifications  bool   `json:"modifications"`
-	Comment        string `json:"comment" example:"This is a comment."`
-	Active         bool   `json:"active" example:"true"`
-	TextUpdatable  bool   `json:"text_updatable"`
-	Md5            string `json:"-"`
+// ObligationPATCHRequestJSONSchema represents the data format of PATCH request for obligation
+type ObligationPATCHRequestJSONSchema struct {
+	Type           OptionalData[string] `json:"type" swaggertype:"string" enums:"obligation,restriction,risk,right"`
+	Text           OptionalData[string] `json:"text" swaggertype:"string" example:"Source code be made available when distributing the software."`
+	Classification OptionalData[string] `json:"classification" swaggertype:"string" enums:"green,white,yellow,red"`
+	Modifications  OptionalData[bool]   `json:"modifications" swaggertype:"boolean"`
+	Comment        OptionalData[string] `json:"comment" swaggertype:"string" example:"This is a comment."`
+	Active         OptionalData[bool]   `json:"active" swaggertype:"boolean" example:"true"`
+	TextUpdatable  OptionalData[bool]   `json:"text_updatable" swaggertype:"boolean"`
 }
 
 // ObligationResponse represents the response format for obligation data.


### PR DESCRIPTION
When we unmarshal json, the undefined keys take zero values in structs. So, there is no way to differentiate between an undefined value and an actual zero value when it is passed in json in a PATCH request.
Example: 
{
    "active": false,
    "text": "Lorem ipsum"
} 
and 
{
    "text": "Lorem ipsum"
} 
Structs of both these unmarshalled json objects will have active as false.