### PR TITLE
fix(license_patch): Fix bug in license patch request

### DIFF
--- a/cmd/laas/docs/docs.go
+++ b/cmd/laas/docs/docs.go
@@ -393,7 +393,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.LicenseInput"
+                            "$ref": "#/definitions/models.LicensePOSTRequestJSONSchema"
                         }
                     }
                 ],
@@ -495,7 +495,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.LicenseUpdate"
+                            "$ref": "#/definitions/models.LicensePATCHRequestJSONSchema"
                         }
                     }
                 ],
@@ -1437,9 +1437,6 @@ const docTemplate = `{
         },
         "models.LicenseDB": {
             "type": "object",
-            "required": [
-                "rf_shortname"
-            ],
             "properties": {
                 "external_ref": {
                     "$ref": "#/definitions/datatypes.JSONType-models_LicenseDBSchemaExtension"
@@ -1544,8 +1541,57 @@ const docTemplate = `{
                 }
             }
         },
-        "models.LicenseInput": {
+        "models.LicenseMapShortnamesElement": {
             "type": "object",
+            "properties": {
+                "add": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "shortname": {
+                    "type": "string",
+                    "example": "GPL-2.0-only"
+                }
+            }
+        },
+        "models.LicenseMapShortnamesInput": {
+            "type": "object",
+            "properties": {
+                "map": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.LicenseMapShortnamesElement"
+                    }
+                }
+            }
+        },
+        "models.LicensePATCHRequestJSONSchema": {
+            "type": "object"
+        },
+        "models.LicensePOSTRequestJSONSchema": {
+            "type": "object",
+            "required": [
+                "external_ref",
+                "marydone",
+                "rf_FSFfree",
+                "rf_Fedora",
+                "rf_GPLv2compatible",
+                "rf_GPLv3compatible",
+                "rf_OSIapproved",
+                "rf_active",
+                "rf_copyleft",
+                "rf_detector_type",
+                "rf_flag",
+                "rf_fullname",
+                "rf_notes",
+                "rf_risk",
+                "rf_shortname",
+                "rf_source",
+                "rf_spdx_id",
+                "rf_text",
+                "rf_text_updatable",
+                "rf_url"
+            ],
             "properties": {
                 "external_ref": {
                     "$ref": "#/definitions/datatypes.JSONType-models_LicenseDBSchemaExtension"
@@ -1570,10 +1616,6 @@ const docTemplate = `{
                 },
                 "rf_active": {
                     "type": "boolean"
-                },
-                "rf_add_date": {
-                    "type": "string",
-                    "example": "2023-12-01T18:10:25.00+05:30"
                 },
                 "rf_copyleft": {
                     "type": "boolean"
@@ -1621,30 +1663,6 @@ const docTemplate = `{
                 }
             }
         },
-        "models.LicenseMapShortnamesElement": {
-            "type": "object",
-            "properties": {
-                "add": {
-                    "type": "boolean",
-                    "example": true
-                },
-                "shortname": {
-                    "type": "string",
-                    "example": "GPL-2.0-only"
-                }
-            }
-        },
-        "models.LicenseMapShortnamesInput": {
-            "type": "object",
-            "properties": {
-                "map": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.LicenseMapShortnamesElement"
-                    }
-                }
-            }
-        },
         "models.LicenseResponse": {
             "type": "object",
             "properties": {
@@ -1675,76 +1693,6 @@ const docTemplate = `{
                         "GPL-2.0-only",
                         "GPL-2.0-or-later"
                     ]
-                }
-            }
-        },
-        "models.LicenseUpdate": {
-            "type": "object",
-            "properties": {
-                "marydone": {
-                    "type": "boolean"
-                },
-                "rf_FSFfree": {
-                    "type": "boolean"
-                },
-                "rf_Fedora": {
-                    "type": "string"
-                },
-                "rf_GPLv2compatible": {
-                    "type": "boolean"
-                },
-                "rf_GPLv3compatible": {
-                    "type": "boolean"
-                },
-                "rf_OSIapproved": {
-                    "type": "boolean"
-                },
-                "rf_active": {
-                    "type": "boolean"
-                },
-                "rf_add_date": {
-                    "type": "string",
-                    "example": "2023-12-01T18:10:25.00+05:30"
-                },
-                "rf_copyleft": {
-                    "type": "boolean"
-                },
-                "rf_detector_type": {
-                    "type": "integer",
-                    "example": 1
-                },
-                "rf_flag": {
-                    "type": "integer",
-                    "example": 1
-                },
-                "rf_fullname": {
-                    "type": "string",
-                    "example": "MIT License"
-                },
-                "rf_notes": {
-                    "type": "string",
-                    "example": "This license has been superseded."
-                },
-                "rf_risk": {
-                    "type": "integer"
-                },
-                "rf_source": {
-                    "type": "string"
-                },
-                "rf_spdx_id": {
-                    "type": "string",
-                    "example": "MIT"
-                },
-                "rf_text": {
-                    "type": "string",
-                    "example": "MIT License Text here"
-                },
-                "rf_text_updatable": {
-                    "type": "boolean"
-                },
-                "rf_url": {
-                    "type": "string",
-                    "example": "https://opensource.org/licenses/MIT"
                 }
             }
         },
@@ -1978,6 +1926,18 @@ const docTemplate = `{
                 "status": {
                     "type": "integer",
                     "example": 200
+                }
+            }
+        },
+        "models.OptionalData-string": {
+            "type": "object",
+            "properties": {
+                "isDefined": {
+                    "description": "This is set to true if corresponding key is present in json object",
+                    "type": "boolean"
+                },
+                "value": {
+                    "type": "string"
                 }
             }
         },

--- a/cmd/laas/docs/swagger.json
+++ b/cmd/laas/docs/swagger.json
@@ -386,7 +386,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.LicenseInput"
+                            "$ref": "#/definitions/models.LicensePOSTRequestJSONSchema"
                         }
                     }
                 ],
@@ -488,7 +488,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/models.LicenseUpdate"
+                            "$ref": "#/definitions/models.LicensePATCHRequestJSONSchema"
                         }
                     }
                 ],
@@ -1430,9 +1430,6 @@
         },
         "models.LicenseDB": {
             "type": "object",
-            "required": [
-                "rf_shortname"
-            ],
             "properties": {
                 "external_ref": {
                     "$ref": "#/definitions/datatypes.JSONType-models_LicenseDBSchemaExtension"
@@ -1537,8 +1534,57 @@
                 }
             }
         },
-        "models.LicenseInput": {
+        "models.LicenseMapShortnamesElement": {
             "type": "object",
+            "properties": {
+                "add": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "shortname": {
+                    "type": "string",
+                    "example": "GPL-2.0-only"
+                }
+            }
+        },
+        "models.LicenseMapShortnamesInput": {
+            "type": "object",
+            "properties": {
+                "map": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.LicenseMapShortnamesElement"
+                    }
+                }
+            }
+        },
+        "models.LicensePATCHRequestJSONSchema": {
+            "type": "object"
+        },
+        "models.LicensePOSTRequestJSONSchema": {
+            "type": "object",
+            "required": [
+                "external_ref",
+                "marydone",
+                "rf_FSFfree",
+                "rf_Fedora",
+                "rf_GPLv2compatible",
+                "rf_GPLv3compatible",
+                "rf_OSIapproved",
+                "rf_active",
+                "rf_copyleft",
+                "rf_detector_type",
+                "rf_flag",
+                "rf_fullname",
+                "rf_notes",
+                "rf_risk",
+                "rf_shortname",
+                "rf_source",
+                "rf_spdx_id",
+                "rf_text",
+                "rf_text_updatable",
+                "rf_url"
+            ],
             "properties": {
                 "external_ref": {
                     "$ref": "#/definitions/datatypes.JSONType-models_LicenseDBSchemaExtension"
@@ -1563,10 +1609,6 @@
                 },
                 "rf_active": {
                     "type": "boolean"
-                },
-                "rf_add_date": {
-                    "type": "string",
-                    "example": "2023-12-01T18:10:25.00+05:30"
                 },
                 "rf_copyleft": {
                     "type": "boolean"
@@ -1614,30 +1656,6 @@
                 }
             }
         },
-        "models.LicenseMapShortnamesElement": {
-            "type": "object",
-            "properties": {
-                "add": {
-                    "type": "boolean",
-                    "example": true
-                },
-                "shortname": {
-                    "type": "string",
-                    "example": "GPL-2.0-only"
-                }
-            }
-        },
-        "models.LicenseMapShortnamesInput": {
-            "type": "object",
-            "properties": {
-                "map": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.LicenseMapShortnamesElement"
-                    }
-                }
-            }
-        },
         "models.LicenseResponse": {
             "type": "object",
             "properties": {
@@ -1668,76 +1686,6 @@
                         "GPL-2.0-only",
                         "GPL-2.0-or-later"
                     ]
-                }
-            }
-        },
-        "models.LicenseUpdate": {
-            "type": "object",
-            "properties": {
-                "marydone": {
-                    "type": "boolean"
-                },
-                "rf_FSFfree": {
-                    "type": "boolean"
-                },
-                "rf_Fedora": {
-                    "type": "string"
-                },
-                "rf_GPLv2compatible": {
-                    "type": "boolean"
-                },
-                "rf_GPLv3compatible": {
-                    "type": "boolean"
-                },
-                "rf_OSIapproved": {
-                    "type": "boolean"
-                },
-                "rf_active": {
-                    "type": "boolean"
-                },
-                "rf_add_date": {
-                    "type": "string",
-                    "example": "2023-12-01T18:10:25.00+05:30"
-                },
-                "rf_copyleft": {
-                    "type": "boolean"
-                },
-                "rf_detector_type": {
-                    "type": "integer",
-                    "example": 1
-                },
-                "rf_flag": {
-                    "type": "integer",
-                    "example": 1
-                },
-                "rf_fullname": {
-                    "type": "string",
-                    "example": "MIT License"
-                },
-                "rf_notes": {
-                    "type": "string",
-                    "example": "This license has been superseded."
-                },
-                "rf_risk": {
-                    "type": "integer"
-                },
-                "rf_source": {
-                    "type": "string"
-                },
-                "rf_spdx_id": {
-                    "type": "string",
-                    "example": "MIT"
-                },
-                "rf_text": {
-                    "type": "string",
-                    "example": "MIT License Text here"
-                },
-                "rf_text_updatable": {
-                    "type": "boolean"
-                },
-                "rf_url": {
-                    "type": "string",
-                    "example": "https://opensource.org/licenses/MIT"
                 }
             }
         },
@@ -1971,6 +1919,18 @@
                 "status": {
                     "type": "integer",
                     "example": 200
+                }
+            }
+        },
+        "models.OptionalData-string": {
+            "type": "object",
+            "properties": {
+                "isDefined": {
+                    "description": "This is set to true if corresponding key is present in json object",
+                    "type": "boolean"
+                },
+                "value": {
+                    "type": "string"
                 }
             }
         },

--- a/cmd/laas/docs/swagger.yaml
+++ b/cmd/laas/docs/swagger.yaml
@@ -128,8 +128,6 @@ definitions:
       rf_url:
         example: https://opensource.org/licenses/MIT
         type: string
-    required:
-    - rf_shortname
     type: object
   models.LicenseError:
     properties:
@@ -149,7 +147,25 @@ definitions:
         example: "2023-12-01T10:00:51+05:30"
         type: string
     type: object
-  models.LicenseInput:
+  models.LicenseMapShortnamesElement:
+    properties:
+      add:
+        example: true
+        type: boolean
+      shortname:
+        example: GPL-2.0-only
+        type: string
+    type: object
+  models.LicenseMapShortnamesInput:
+    properties:
+      map:
+        items:
+          $ref: '#/definitions/models.LicenseMapShortnamesElement'
+        type: array
+    type: object
+  models.LicensePATCHRequestJSONSchema:
+    type: object
+  models.LicensePOSTRequestJSONSchema:
     properties:
       external_ref:
         $ref: '#/definitions/datatypes.JSONType-models_LicenseDBSchemaExtension'
@@ -167,9 +183,6 @@ definitions:
         type: boolean
       rf_active:
         type: boolean
-      rf_add_date:
-        example: "2023-12-01T18:10:25.00+05:30"
-        type: string
       rf_copyleft:
         type: boolean
       rf_detector_type:
@@ -202,22 +215,27 @@ definitions:
       rf_url:
         example: https://opensource.org/licenses/MIT
         type: string
-    type: object
-  models.LicenseMapShortnamesElement:
-    properties:
-      add:
-        example: true
-        type: boolean
-      shortname:
-        example: GPL-2.0-only
-        type: string
-    type: object
-  models.LicenseMapShortnamesInput:
-    properties:
-      map:
-        items:
-          $ref: '#/definitions/models.LicenseMapShortnamesElement'
-        type: array
+    required:
+    - external_ref
+    - marydone
+    - rf_FSFfree
+    - rf_Fedora
+    - rf_GPLv2compatible
+    - rf_GPLv3compatible
+    - rf_OSIapproved
+    - rf_active
+    - rf_copyleft
+    - rf_detector_type
+    - rf_flag
+    - rf_fullname
+    - rf_notes
+    - rf_risk
+    - rf_shortname
+    - rf_source
+    - rf_spdx_id
+    - rf_text
+    - rf_text_updatable
+    - rf_url
     type: object
   models.LicenseResponse:
     properties:
@@ -240,55 +258,6 @@ definitions:
         items:
           type: string
         type: array
-    type: object
-  models.LicenseUpdate:
-    properties:
-      marydone:
-        type: boolean
-      rf_FSFfree:
-        type: boolean
-      rf_Fedora:
-        type: string
-      rf_GPLv2compatible:
-        type: boolean
-      rf_GPLv3compatible:
-        type: boolean
-      rf_OSIapproved:
-        type: boolean
-      rf_active:
-        type: boolean
-      rf_add_date:
-        example: "2023-12-01T18:10:25.00+05:30"
-        type: string
-      rf_copyleft:
-        type: boolean
-      rf_detector_type:
-        example: 1
-        type: integer
-      rf_flag:
-        example: 1
-        type: integer
-      rf_fullname:
-        example: MIT License
-        type: string
-      rf_notes:
-        example: This license has been superseded.
-        type: string
-      rf_risk:
-        type: integer
-      rf_source:
-        type: string
-      rf_spdx_id:
-        example: MIT
-        type: string
-      rf_text:
-        example: MIT License Text here
-        type: string
-      rf_text_updatable:
-        type: boolean
-      rf_url:
-        example: https://opensource.org/licenses/MIT
-        type: string
     type: object
   models.Obligation:
     properties:
@@ -457,6 +426,14 @@ definitions:
       status:
         example: 200
         type: integer
+    type: object
+  models.OptionalData-string:
+    properties:
+      isDefined:
+        description: This is set to true if corresponding key is present in json object
+        type: boolean
+      value:
+        type: string
     type: object
   models.PaginationMeta:
     properties:
@@ -801,7 +778,7 @@ paths:
         name: license
         required: true
         schema:
-          $ref: '#/definitions/models.LicenseInput'
+          $ref: '#/definitions/models.LicensePOSTRequestJSONSchema'
       produces:
       - application/json
       responses:
@@ -868,7 +845,7 @@ paths:
         name: license
         required: true
         schema:
-          $ref: '#/definitions/models.LicenseUpdate'
+          $ref: '#/definitions/models.LicensePATCHRequestJSONSchema'
       produces:
       - application/json
       responses:

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -17,7 +17,7 @@ import (
 // It provides structured storage for license-related information.
 type LicenseDB struct {
 	Id              int64                                        `json:"rf_id" gorm:"primary_key;column:rf_id" example:"123"`
-	Shortname       string                                       `json:"rf_shortname" gorm:"unique;not null;column:rf_shortname" binding:"required" example:"MIT"`
+	Shortname       string                                       `json:"rf_shortname" gorm:"unique;not null;column:rf_shortname" example:"MIT"`
 	Fullname        string                                       `json:"rf_fullname" gorm:"column:rf_fullname" example:"MIT License"`
 	Text            string                                       `json:"rf_text" gorm:"column:rf_text" example:"MIT License Text here"`
 	Url             string                                       `json:"rf_url" gorm:"column:rf_url" example:"https://opensource.org/licenses/MIT"`
@@ -38,6 +38,31 @@ type LicenseDB struct {
 	Flag            int64                                        `json:"rf_flag" gorm:"default:1;column:rf_flag" example:"1"`
 	Marydone        bool                                         `json:"marydone" gorm:"column:marydone"`
 	ExternalRef     datatypes.JSONType[LicenseDBSchemaExtension] `json:"external_ref"`
+}
+
+// LicensePOSTRequestJSONSchema struct represents the input or payload required for creating a license.
+// It contains various fields that capture the necessary information for defining a license entity.
+type LicensePOSTRequestJSONSchema struct {
+	Shortname       string                                       `json:"rf_shortname" binding:"required" example:"MIT"`
+	Fullname        string                                       `json:"rf_fullname" binding:"required" example:"MIT License"`
+	Text            string                                       `json:"rf_text" binding:"required" example:"MIT License Text here"`
+	Url             string                                       `json:"rf_url" binding:"required" example:"https://opensource.org/licenses/MIT"`
+	Copyleft        bool                                         `json:"rf_copyleft" binding:"required"`
+	FSFfree         bool                                         `json:"rf_FSFfree" binding:"required"`
+	OSIapproved     bool                                         `json:"rf_OSIapproved" binding:"required"`
+	GPLv2compatible bool                                         `json:"rf_GPLv2compatible" binding:"required"`
+	GPLv3compatible bool                                         `json:"rf_GPLv3compatible" binding:"required"`
+	Notes           string                                       `json:"rf_notes" example:"This license has been superseded." binding:"required"`
+	Fedora          string                                       `json:"rf_Fedora" binding:"required"`
+	TextUpdatable   bool                                         `json:"rf_text_updatable" binding:"required"`
+	DetectorType    int64                                        `json:"rf_detector_type" example:"1" binding:"required"`
+	Active          bool                                         `json:"rf_active" binding:"required"`
+	Source          string                                       `json:"rf_source" binding:"required"`
+	SpdxId          string                                       `json:"rf_spdx_id" binding:"required" example:"MIT"`
+	Risk            int64                                        `json:"rf_risk" binding:"required"`
+	Flag            int64                                        `json:"rf_flag" binding:"required" example:"1"`
+	Marydone        bool                                         `json:"marydone" binding:"required"`
+	ExternalRef     datatypes.JSONType[LicenseDBSchemaExtension] `json:"external_ref" binding:"required"`
 }
 
 type LicenseJson struct {
@@ -63,28 +88,27 @@ type LicenseJson struct {
 	Marydone        string `json:"marydone"`
 }
 
-// LicenseUpdate struct represents the input format for updating an existing license.
+// LicensePATCHRequestJSONSchema struct represents the input format for updating an existing license.
 // Note that the license ID and shortname cannot be updated.
-type LicenseUpdate struct {
-	Fullname        string    `json:"rf_fullname" gorm:"column:rf_fullname" example:"MIT License"`
-	Text            string    `json:"rf_text" gorm:"column:rf_text" example:"MIT License Text here"`
-	Url             string    `json:"rf_url" gorm:"column:rf_url" example:"https://opensource.org/licenses/MIT"`
-	AddDate         time.Time `json:"rf_add_date" gorm:"default:CURRENT_TIMESTAMP;column:rf_add_date" example:"2023-12-01T18:10:25.00+05:30"`
-	Copyleft        bool      `json:"rf_copyleft" gorm:"column:rf_copyleft"`
-	FSFfree         bool      `json:"rf_FSFfree" gorm:"column:rf_FSFfree"`
-	OSIapproved     bool      `json:"rf_OSIapproved" gorm:"column:rf_OSIapproved"`
-	GPLv2compatible bool      `json:"rf_GPLv2compatible" gorm:"column:rf_GPLv2compatible"`
-	GPLv3compatible bool      `json:"rf_GPLv3compatible" gorm:"column:rf_GPLv3compatible"`
-	Notes           string    `json:"rf_notes" gorm:"column:rf_notes" example:"This license has been superseded."`
-	Fedora          string    `json:"rf_Fedora" gorm:"column:rf_Fedora"`
-	TextUpdatable   bool      `json:"rf_text_updatable" gorm:"column:rf_text_updatable"`
-	DetectorType    int64     `json:"rf_detector_type" gorm:"column:rf_detector_type" example:"1"`
-	Active          bool      `json:"rf_active" gorm:"column:rf_active"`
-	Source          string    `json:"rf_source" gorm:"column:rf_source"`
-	SpdxId          string    `json:"rf_spdx_id" gorm:"column:rf_spdx_id" example:"MIT"`
-	Risk            int64     `json:"rf_risk" gorm:"column:rf_risk"`
-	Flag            int64     `json:"rf_flag" gorm:"default:1;column:rf_flag" example:"1"`
-	Marydone        bool      `json:"marydone" gorm:"column:marydone"`
+type LicensePATCHRequestJSONSchema struct {
+	Fullname        OptionalData[string] `json:"rf_fullname" example:"MIT License"`
+	Text            OptionalData[string] `json:"rf_text" example:"MIT License Text here"`
+	Url             OptionalData[string] `json:"rf_url" example:"https://opensource.org/licenses/MIT"`
+	Copyleft        OptionalData[bool]   `json:"rf_copyleft"`
+	FSFfree         OptionalData[bool]   `json:"rf_FSFfree"`
+	OSIapproved     OptionalData[bool]   `json:"rf_OSIapproved"`
+	GPLv2compatible OptionalData[bool]   `json:"rf_GPLv2compatible"`
+	GPLv3compatible OptionalData[bool]   `json:"rf_GPLv3compatible"`
+	Notes           OptionalData[string] `json:"rf_notes" example:"This license has been superseded."`
+	Fedora          OptionalData[string] `json:"rf_Fedora"`
+	TextUpdatable   OptionalData[bool]   `json:"rf_text_updatable"`
+	DetectorType    OptionalData[int64]  `json:"rf_detector_type" example:"1"`
+	Active          OptionalData[bool]   `json:"rf_active"`
+	Source          OptionalData[string] `json:"rf_source"`
+	SpdxId          OptionalData[string] `json:"rf_spdx_id" example:"MIT"`
+	Risk            OptionalData[int64]  `json:"rf_risk"`
+	Flag            OptionalData[int64]  `json:"rf_flag" example:"1"`
+	Marydone        OptionalData[bool]   `json:"marydone"`
 }
 
 // UpdateExternalRefsJSONPayload struct represents the external ref key value
@@ -147,32 +171,6 @@ type LicenseError struct {
 	Error     string `json:"error" example:"invalid request body"`
 	Path      string `json:"path" example:"/api/v1/licenses"`
 	Timestamp string `json:"timestamp" example:"2023-12-01T10:00:51+05:30"`
-}
-
-// The LicenseInput struct represents the input or payload required for creating a license.
-// It contains various fields that capture the necessary information for defining a license entity.
-type LicenseInput struct {
-	Shortname       string                                       `json:"rf_shortname" example:"MIT"`
-	Fullname        string                                       `json:"rf_fullname" example:"MIT License"`
-	Text            string                                       `json:"rf_text" example:"MIT License Text here"`
-	Url             string                                       `json:"rf_url" example:"https://opensource.org/licenses/MIT"`
-	AddDate         time.Time                                    `json:"rf_add_date" example:"2023-12-01T18:10:25.00+05:30"`
-	Copyleft        bool                                         `json:"rf_copyleft"`
-	FSFfree         bool                                         `json:"rf_FSFfree"`
-	OSIapproved     bool                                         `json:"rf_OSIapproved"`
-	GPLv2compatible bool                                         `json:"rf_GPLv2compatible"`
-	GPLv3compatible bool                                         `json:"rf_GPLv3compatible"`
-	Notes           string                                       `json:"rf_notes" example:"This license has been superseded."`
-	Fedora          string                                       `json:"rf_Fedora"`
-	TextUpdatable   bool                                         `json:"rf_text_updatable"`
-	DetectorType    int64                                        `json:"rf_detector_type" example:"1"`
-	Active          bool                                         `json:"rf_active"`
-	Source          string                                       `json:"rf_source"`
-	SpdxId          string                                       `json:"rf_spdx_id" example:"MIT"`
-	Risk            int64                                        `json:"rf_risk"`
-	Flag            int64                                        `json:"rf_flag" example:"1"`
-	Marydone        bool                                         `json:"marydone"`
-	ExternalRef     datatypes.JSONType[LicenseDBSchemaExtension] `json:"external_ref"`
 }
 
 // User struct is representation of user information.


### PR DESCRIPTION
Resolves the following:
1. When we unmarshal json, the undefined keys take zero values in structs. So, there is no way to differentiate between an undefined value and an actual zero value when it is passed in json in a PATCH request.
Example:
{
"active": false,
"text": "Lorem ipsum"
}
and
{
"text": "Lorem ipsum"
}
Structs of both these unmarshalled json objects will have active as false.
2. Also, updates with struct having fields as null values won't be considered for update in database. 