### PR TITLE
feat(license_import): Add endpoint to import licenses via a json file

### DIFF
--- a/cmd/laas/docs/docs.go
+++ b/cmd/laas/docs/docs.go
@@ -425,6 +425,71 @@ const docTemplate = `{
                 }
             }
         },
+        "/licenses/import": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Import licenses by uploading a json file",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Licenses"
+                ],
+                "summary": "Import licenses by uploading a json file",
+                "operationId": "ImportLicenses",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "licenses json file list",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/models.ImportLicensesResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/models.LicenseImportStatus"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "input file must be present",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    }
+                }
+            }
+        },
         "/licenses/{shortname}": {
             "get": {
                 "description": "Get a single license by its shortname",
@@ -1421,6 +1486,20 @@ const docTemplate = `{
                 }
             }
         },
+        "models.ImportLicensesResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "can be of type models.LicenseError or models.LicenseImportStatus",
+                    "type": "array",
+                    "items": {}
+                },
+                "status": {
+                    "type": "integer",
+                    "example": 200
+                }
+            }
+        },
         "models.ImportObligationsResponse": {
             "type": "object",
             "properties": {
@@ -1538,6 +1617,31 @@ const docTemplate = `{
                 "timestamp": {
                     "type": "string",
                     "example": "2023-12-01T10:00:51+05:30"
+                }
+            }
+        },
+        "models.LicenseId": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "example": 31
+                },
+                "shortname": {
+                    "type": "string",
+                    "example": "MIT"
+                }
+            }
+        },
+        "models.LicenseImportStatus": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.LicenseId"
+                },
+                "status": {
+                    "type": "integer",
+                    "example": 200
                 }
             }
         },

--- a/cmd/laas/docs/swagger.json
+++ b/cmd/laas/docs/swagger.json
@@ -418,6 +418,71 @@
                 }
             }
         },
+        "/licenses/import": {
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Import licenses by uploading a json file",
+                "consumes": [
+                    "multipart/form-data"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Licenses"
+                ],
+                "summary": "Import licenses by uploading a json file",
+                "operationId": "ImportLicenses",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "licenses json file list",
+                        "name": "file",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/models.ImportLicensesResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/models.LicenseImportStatus"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "input file must be present",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    }
+                }
+            }
+        },
         "/licenses/{shortname}": {
             "get": {
                 "description": "Get a single license by its shortname",
@@ -1414,6 +1479,20 @@
                 }
             }
         },
+        "models.ImportLicensesResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "can be of type models.LicenseError or models.LicenseImportStatus",
+                    "type": "array",
+                    "items": {}
+                },
+                "status": {
+                    "type": "integer",
+                    "example": 200
+                }
+            }
+        },
         "models.ImportObligationsResponse": {
             "type": "object",
             "properties": {
@@ -1531,6 +1610,31 @@
                 "timestamp": {
                     "type": "string",
                     "example": "2023-12-01T10:00:51+05:30"
+                }
+            }
+        },
+        "models.LicenseId": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "example": 31
+                },
+                "shortname": {
+                    "type": "string",
+                    "example": "MIT"
+                }
+            }
+        },
+        "models.LicenseImportStatus": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "$ref": "#/definitions/models.LicenseId"
+                },
+                "status": {
+                    "type": "integer",
+                    "example": 200
                 }
             }
         },

--- a/cmd/laas/docs/swagger.yaml
+++ b/cmd/laas/docs/swagger.yaml
@@ -62,6 +62,16 @@ definitions:
         example: 200
         type: integer
     type: object
+  models.ImportLicensesResponse:
+    properties:
+      data:
+        description: can be of type models.LicenseError or models.LicenseImportStatus
+        items: {}
+        type: array
+      status:
+        example: 200
+        type: integer
+    type: object
   models.ImportObligationsResponse:
     properties:
       data:
@@ -146,6 +156,23 @@ definitions:
       timestamp:
         example: "2023-12-01T10:00:51+05:30"
         type: string
+    type: object
+  models.LicenseId:
+    properties:
+      id:
+        example: 31
+        type: integer
+      shortname:
+        example: MIT
+        type: string
+    type: object
+  models.LicenseImportStatus:
+    properties:
+      data:
+        $ref: '#/definitions/models.LicenseId'
+      status:
+        example: 200
+        type: integer
     type: object
   models.LicenseMapShortnamesElement:
     properties:
@@ -872,6 +899,45 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Update a license
+      tags:
+      - Licenses
+  /licenses/import:
+    post:
+      consumes:
+      - multipart/form-data
+      description: Import licenses by uploading a json file
+      operationId: ImportLicenses
+      parameters:
+      - description: licenses json file list
+        in: formData
+        name: file
+        required: true
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/models.ImportLicensesResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/models.LicenseImportStatus'
+                  type: array
+              type: object
+        "400":
+          description: input file must be present
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+      security:
+      - ApiKeyAuth: []
+      summary: Import licenses by uploading a json file
       tags:
       - Licenses
   /login:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -104,6 +104,7 @@ func Router() *gin.Engine {
 		{
 			licenses.POST("", CreateLicense)
 			licenses.PATCH(":shortname", UpdateLicense)
+			licenses.POST("import", ImportLicenses)
 		}
 		users := authorizedv1.Group("/users")
 		{

--- a/pkg/models/optional_data_types.go
+++ b/pkg/models/optional_data_types.go
@@ -36,3 +36,25 @@ func (v *OptionalData[T]) UnmarshalJSON(data []byte) error {
 	}
 	return nil
 }
+
+type NullableAndOptionalData[T any] struct {
+	// This is set to true if corresponding key is present in json object
+	IsDefinedAndNotNull bool
+	rawJson             json.RawMessage
+	Value               T
+}
+
+func (v *NullableAndOptionalData[T]) UnmarshalJSON(data []byte) error {
+	v.rawJson = append((v.rawJson)[0:0], data...)
+	if len(v.rawJson) != 0 {
+		var x *T
+		if err := json.Unmarshal(data, &x); err != nil {
+			return err
+		}
+		if x != nil {
+			v.Value = *x
+			v.IsDefinedAndNotNull = true
+		}
+	}
+	return nil
+}

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -117,6 +117,59 @@ type UpdateExternalRefsJSONPayload struct {
 	ExternalRef map[string]interface{} `json:"external_ref"`
 }
 
+// LicenseImport represents an license record in the import json file.
+type LicenseImport struct {
+	Shortname       NullableAndOptionalData[string] `json:"rf_shortname" validate:"required" example:"MIT"`
+	Fullname        NullableAndOptionalData[string] `json:"rf_fullname" validate:"required" example:"MIT License"`
+	Text            NullableAndOptionalData[string] `json:"rf_text" validate:"required" example:"MIT License Text here"`
+	Url             NullableAndOptionalData[string] `json:"rf_url" validate:"required" example:"https://opensource.org/licenses/MIT"`
+	Copyleft        NullableAndOptionalData[bool]   `json:"rf_copyleft"`
+	FSFfree         NullableAndOptionalData[bool]   `json:"rf_FSFfree"`
+	OSIapproved     NullableAndOptionalData[bool]   `json:"rf_OSIapproved"`
+	GPLv2compatible NullableAndOptionalData[bool]   `json:"rf_GPLv2compatible"`
+	GPLv3compatible NullableAndOptionalData[bool]   `json:"rf_GPLv3compatible"`
+	Notes           NullableAndOptionalData[string] `json:"rf_notes" example:"This license has been superseded."`
+	Fedora          NullableAndOptionalData[string] `json:"rf_Fedora"`
+	TextUpdatable   NullableAndOptionalData[bool]   `json:"rf_text_updatable" validate:"required"`
+	DetectorType    NullableAndOptionalData[int64]  `json:"rf_detector_type" example:"1"`
+	Active          NullableAndOptionalData[bool]   `json:"rf_active" validate:"required"`
+	Source          NullableAndOptionalData[string] `json:"rf_source" validate:"required"`
+	SpdxId          NullableAndOptionalData[string] `json:"rf_spdx_id" validate:"required" example:"MIT"`
+	Risk            NullableAndOptionalData[int64]  `json:"rf_risk" validate:"required"`
+	Flag            NullableAndOptionalData[int64]  `json:"rf_flag"`
+	Marydone        NullableAndOptionalData[bool]   `json:"marydone"`
+	ExternalRef     map[string]interface{}          `json:"external_ref"`
+}
+
+// LicenseImportStatusCode is internally used for checking status of a license import
+type LicenseImportStatusCode int
+
+// Status codes covering various scenarios that can occur on a license import
+const (
+	IMPORT_FAILED LicenseImportStatusCode = iota + 1
+	IMPORT_LICENSE_CREATED
+	IMPORT_LICENSE_UPDATED
+	IMPORT_LICENSE_UPDATED_EXCEPT_TEXT
+)
+
+// LicenseId is the id of successfully imported license
+type LicenseId struct {
+	Id        int64  `json:"id" example:"31"`
+	Shortname string `json:"shortname" example:"MIT"`
+}
+
+// LicenseImportStatus is the status of license records successfully inserted in the database during import
+type LicenseImportStatus struct {
+	Status int       `json:"status" example:"200"`
+	Data   LicenseId `json:"data"`
+}
+
+// ImportObligationsResponse is the response structure for import obligation response
+type ImportLicensesResponse struct {
+	Status int           `json:"status" example:"200"`
+	Data   []interface{} `json:"data"` // can be of type models.LicenseError or models.LicenseImportStatus
+}
+
 // The PaginationMeta struct represents additional metadata associated with a
 // license retrieval operation.
 // It contains information that provides context and supplementary details


### PR DESCRIPTION
### Code Overview:
- Made a generic function  `InsertOrUpdateLicenseOnImport` for creating/updating a single license on import. This function will be used in both `Populatedb` function and */licenses/import* endpoint. 
-`InsertOrUpdateLicenseOnImport` takes input a *map* of license fields. This was done to accomodate updates of fields with zero values as valid values( ex. Risk can be 0, Active can be false ). GORM doesn't update fields with zero values when updating using a struct.
- Logic of `addChangelogsForLicenseUpdate` was kept seperate from `InsertOrUpdateLicenseOnImport` to make the latter generic. `Populatedb` won't need `addChangelogsForLicenseUpdate`.
- A new template datatype `NullableAndOptionalData` was introduced to differentiate between fields with zero values and fields with null values/undefined fields in json(in all the cases the unmarshalled struct will have zero values).
- `InsertOrUpdateLicenseOnImport` will be added to `Populatedb` in next PR to keep this PR size manageable.
- `InsertOrUpdateLicenseOnImport` returns `errMessage` and `importStatus` along with some license structs to make it generic. This was done because in endpoint, the relevant data will be added to response body while it will be logged in 'Populatedb'. 

### Behaviour:
- Inserts a new license to database if not already present(checks by shortname).
- Updates the license with new values if license already present. 
- Updates the license with new values except for *rf_text* if *rf_flag* is set to 2(if this flag is set to 2, it means that the license text was updated manually and should not be updated via an import).
