### PR TITLE
feat(obligations_preview): Create an endpoint to fetch topic and type of all obligations

### DIFF
--- a/cmd/laas/docs/docs.go
+++ b/cmd/laas/docs/docs.go
@@ -1075,6 +1075,39 @@ const docTemplate = `{
                 }
             }
         },
+        "/obligations/preview": {
+            "get": {
+                "description": "Get topic and type of all active obligations from the service",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Obligations"
+                ],
+                "summary": "Get topic and types of all active obligations",
+                "operationId": "GetAllObligationPreviews",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Active obligation only",
+                        "name": "active",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.ObligationPreviewResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/obligations/{topic}": {
             "get": {
                 "description": "Get an active based on given topic",
@@ -2298,6 +2331,39 @@ const docTemplate = `{
                         "risk",
                         "right"
                     ]
+                }
+            }
+        },
+        "models.ObligationPreview": {
+            "type": "object",
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "example": "Provide Copyright Notices"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "obligation",
+                        "restriction",
+                        "risk",
+                        "right"
+                    ]
+                }
+            }
+        },
+        "models.ObligationPreviewResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.ObligationPreview"
+                    }
+                },
+                "status": {
+                    "type": "integer",
+                    "example": 200
                 }
             }
         },

--- a/cmd/laas/docs/swagger.json
+++ b/cmd/laas/docs/swagger.json
@@ -1068,6 +1068,39 @@
                 }
             }
         },
+        "/obligations/preview": {
+            "get": {
+                "description": "Get topic and type of all active obligations from the service",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Obligations"
+                ],
+                "summary": "Get topic and types of all active obligations",
+                "operationId": "GetAllObligationPreviews",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Active obligation only",
+                        "name": "active",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.ObligationPreviewResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/obligations/{topic}": {
             "get": {
                 "description": "Get an active based on given topic",
@@ -2291,6 +2324,39 @@
                         "risk",
                         "right"
                     ]
+                }
+            }
+        },
+        "models.ObligationPreview": {
+            "type": "object",
+            "properties": {
+                "topic": {
+                    "type": "string",
+                    "example": "Provide Copyright Notices"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "obligation",
+                        "restriction",
+                        "risk",
+                        "right"
+                    ]
+                }
+            }
+        },
+        "models.ObligationPreviewResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.ObligationPreview"
+                    }
+                },
+                "status": {
+                    "type": "integer",
+                    "example": 200
                 }
             }
         },

--- a/cmd/laas/docs/swagger.yaml
+++ b/cmd/laas/docs/swagger.yaml
@@ -592,6 +592,29 @@ definitions:
     - topic
     - type
     type: object
+  models.ObligationPreview:
+    properties:
+      topic:
+        example: Provide Copyright Notices
+        type: string
+      type:
+        enum:
+        - obligation
+        - restriction
+        - risk
+        - right
+        type: string
+    type: object
+  models.ObligationPreviewResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/models.ObligationPreview'
+        type: array
+      status:
+        example: 200
+        type: integer
+    type: object
   models.ObligationResponse:
     properties:
       data:
@@ -1522,6 +1545,28 @@ paths:
       security:
       - ApiKeyAuth: []
       summary: Import obligations by uploading a json file
+      tags:
+      - Obligations
+  /obligations/preview:
+    get:
+      consumes:
+      - application/json
+      description: Get topic and type of all active obligations from the service
+      operationId: GetAllObligationPreviews
+      parameters:
+      - description: Active obligation only
+        in: query
+        name: active
+        required: true
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.ObligationPreviewResponse'
+      summary: Get topic and types of all active obligations
       tags:
       - Obligations
   /search:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -80,6 +80,7 @@ func Router() *gin.Engine {
 		obligations := unAuthorizedv1.Group("/obligations")
 		{
 			obligations.GET("", GetAllObligation)
+			obligations.GET("/preview", GetAllObligationPreviews)
 			obligations.GET(":topic", GetObligation)
 			obligations.GET(":topic/audits", GetObligationAudits)
 			obligations.GET("export", ExportObligations)

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -333,6 +333,18 @@ type Obligation struct {
 	Md5            string `gorm:"unique" json:"-"`
 }
 
+// ObligationPreview is just the Type and Topic of Obligation
+type ObligationPreview struct {
+	Topic string `json:"topic" example:"Provide Copyright Notices"`
+	Type  string `json:"type" enums:"obligation,restriction,risk,right"`
+}
+
+// ObligationResponse represents the response format for obligation data.
+type ObligationPreviewResponse struct {
+	Status int                 `json:"status" example:"200"`
+	Data   []ObligationPreview `json:"data"`
+}
+
 // ObligationPOSTRequestJSONSchema represents the data format of POST request for obligation
 type ObligationPOSTRequestJSONSchema struct {
 	Topic          string   `json:"topic" binding:"required" example:"copyleft"`


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Avinal Kumar <avinal.xlvii@gmail.com>
SPDX-License-Identifier: GPL-2.0-only

Thank you for the pull request. Please fill this template as much as
possible and delete unused parts.
-->

## Changes

<!-- Describe your changes here. Ideally GitHub can get the description
from your descriptive commit message(s). Link issues/PR that are relevant
for your changes.-->

- Create an endpoint to fetch topic and type of all obligations. This data will be displayed as options in the multiselect input which adds obligations to a license. 


## Submitter Checklist

- [ ] Includes tests (if there is a feature changed/added)
- [X] Includes docs ( if changes are user facing)
- [X] I have tested my changes locally.

## References
![Screenshot from 2024-06-07 14-44-10](https://github.com/fossology/LicenseDb/assets/59907159/fc1a6f91-0941-43a6-805b-624fb86c77e0)

<!-- Add any supporting links/screenshot/logs etc here. If not needed please
delete this block.-->

