### PR TITLE
fix(license_obligations): Add type field to response

### DIFF
--- a/cmd/laas/docs/docs.go
+++ b/cmd/laas/docs/docs.go
@@ -2196,6 +2196,16 @@ const docTemplate = `{
                 "topic": {
                     "type": "string",
                     "example": "copyleft"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "obligation",
+                        "restriction",
+                        "risk",
+                        "right"
+                    ],
+                    "example": "obligation"
                 }
             }
         },

--- a/cmd/laas/docs/swagger.json
+++ b/cmd/laas/docs/swagger.json
@@ -2189,6 +2189,16 @@
                 "topic": {
                     "type": "string",
                     "example": "copyleft"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "obligation",
+                        "restriction",
+                        "risk",
+                        "right"
+                    ],
+                    "example": "obligation"
                 }
             }
         },

--- a/cmd/laas/docs/swagger.yaml
+++ b/cmd/laas/docs/swagger.yaml
@@ -515,6 +515,14 @@ definitions:
       topic:
         example: copyleft
         type: string
+      type:
+        enum:
+        - obligation
+        - restriction
+        - risk
+        - right
+        example: obligation
+        type: string
     type: object
   models.ObligationPATCHRequestJSONSchema:
     properties:

--- a/pkg/api/obligationmap.go
+++ b/pkg/api/obligationmap.go
@@ -84,6 +84,7 @@ func GetObligationMapByTopic(c *gin.Context) {
 
 	resObMap = models.ObligationMapUser{
 		Topic:      topic,
+		Type:       obligation.Type,
 		Shortnames: shortnameList,
 	}
 
@@ -155,6 +156,7 @@ func GetObligationMapByLicense(c *gin.Context) {
 			return
 		}
 		resObMapList = append(resObMapList, models.ObligationMapUser{
+			Type:       obligation.Type,
 			Topic:      obligation.Topic,
 			Shortnames: []string{licenseShortName},
 		})
@@ -538,6 +540,7 @@ func createObligationMapUser(obligation models.Obligation, obMaps []models.Oblig
 	}
 	return &models.ObligationMapUser{
 		Topic:      obligation.Topic,
+		Type:       obligation.Type,
 		Shortnames: shortnameList,
 	}, nil
 }

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -375,6 +375,7 @@ type ObligationMap struct {
 // ObligationMapUser Structure with obligation topic and license shortname list, a simple representation for user.
 type ObligationMapUser struct {
 	Topic      string   `json:"topic" example:"copyleft"`
+	Type       string   `json:"type" example:"obligation" enums:"obligation,restriction,risk,right"`
 	Shortnames []string `json:"shortnames" example:"GPL-2.0-only,GPL-2.0-or-later"`
 }
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Avinal Kumar <avinal.xlvii@gmail.com>
SPDX-License-Identifier: GPL-2.0-only

Thank you for the pull request. Please fill this template as much as
possible and delete unused parts.
-->

## Changes

<!-- Describe your changes here. Ideally GitHub can get the description
from your descriptive commit message(s). Link issues/PR that are relevant
for your changes.-->

- <!-- describe your changes here -->Add type field to reponse of /obligation_maps/license/{license}. It is needed for display in UI.

## Submitter Checklist

- [ ] Includes tests (if there is a feature changed/added)
- [X] Includes docs ( if changes are user facing)
- [X] I have tested my changes locally.

## References

<!-- Add any supporting links/screenshot/logs etc here. If not needed please
delete this block.-->
![image](https://github.com/fossology/LicenseDb/assets/59907159/3b19ce30-69b4-4530-a908-59206c10c97c)


