### PR TITLE
Add license/obligation and user data to audit json response

### DIFF
--- a/cmd/laas/docs/docs.go
+++ b/cmd/laas/docs/docs.go
@@ -1594,6 +1594,9 @@ const docTemplate = `{
         "models.Audit": {
             "type": "object",
             "properties": {
+                "entity": {
+                    "type": "object"
+                },
                 "id": {
                     "type": "integer",
                     "example": 456
@@ -1604,11 +1607,18 @@ const docTemplate = `{
                 },
                 "type": {
                     "type": "string",
+                    "enum": [
+                        "obligation",
+                        "license"
+                    ],
                     "example": "license"
                 },
                 "type_id": {
                     "type": "integer",
                     "example": 34
+                },
+                "user": {
+                    "$ref": "#/definitions/models.User"
                 },
                 "user_id": {
                     "type": "integer",

--- a/cmd/laas/docs/docs.go
+++ b/cmd/laas/docs/docs.go
@@ -2563,7 +2563,6 @@ const docTemplate = `{
         "models.User": {
             "type": "object",
             "required": [
-                "password",
                 "userlevel",
                 "username"
             ],
@@ -2571,9 +2570,6 @@ const docTemplate = `{
                 "id": {
                     "type": "integer",
                     "example": 123
-                },
-                "password": {
-                    "type": "string"
                 },
                 "userlevel": {
                     "type": "string",
@@ -2594,7 +2590,8 @@ const docTemplate = `{
             ],
             "properties": {
                 "password": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "fossy"
                 },
                 "userlevel": {
                     "type": "string",
@@ -2614,7 +2611,8 @@ const docTemplate = `{
             ],
             "properties": {
                 "password": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "fossy"
                 },
                 "username": {
                     "type": "string",

--- a/cmd/laas/docs/swagger.json
+++ b/cmd/laas/docs/swagger.json
@@ -1587,6 +1587,9 @@
         "models.Audit": {
             "type": "object",
             "properties": {
+                "entity": {
+                    "type": "object"
+                },
                 "id": {
                     "type": "integer",
                     "example": 456
@@ -1597,11 +1600,18 @@
                 },
                 "type": {
                     "type": "string",
+                    "enum": [
+                        "obligation",
+                        "license"
+                    ],
                     "example": "license"
                 },
                 "type_id": {
                     "type": "integer",
                     "example": 34
+                },
+                "user": {
+                    "$ref": "#/definitions/models.User"
                 },
                 "user_id": {
                     "type": "integer",

--- a/cmd/laas/docs/swagger.json
+++ b/cmd/laas/docs/swagger.json
@@ -2556,7 +2556,6 @@
         "models.User": {
             "type": "object",
             "required": [
-                "password",
                 "userlevel",
                 "username"
             ],
@@ -2564,9 +2563,6 @@
                 "id": {
                     "type": "integer",
                     "example": 123
-                },
-                "password": {
-                    "type": "string"
                 },
                 "userlevel": {
                     "type": "string",
@@ -2587,7 +2583,8 @@
             ],
             "properties": {
                 "password": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "fossy"
                 },
                 "userlevel": {
                     "type": "string",
@@ -2607,7 +2604,8 @@
             ],
             "properties": {
                 "password": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "fossy"
                 },
                 "username": {
                     "type": "string",

--- a/cmd/laas/docs/swagger.yaml
+++ b/cmd/laas/docs/swagger.yaml
@@ -701,8 +701,6 @@ definitions:
       id:
         example: 123
         type: integer
-      password:
-        type: string
       userlevel:
         example: admin
         type: string
@@ -710,13 +708,13 @@ definitions:
         example: fossy
         type: string
     required:
-    - password
     - userlevel
     - username
     type: object
   models.UserInput:
     properties:
       password:
+        example: fossy
         type: string
       userlevel:
         example: admin
@@ -732,6 +730,7 @@ definitions:
   models.UserLogin:
     properties:
       password:
+        example: fossy
         type: string
       username:
         example: fossy

--- a/cmd/laas/docs/swagger.yaml
+++ b/cmd/laas/docs/swagger.yaml
@@ -4,6 +4,8 @@ definitions:
     type: object
   models.Audit:
     properties:
+      entity:
+        type: object
       id:
         example: 456
         type: integer
@@ -11,11 +13,16 @@ definitions:
         example: "2023-12-01T18:10:25.00+05:30"
         type: string
       type:
+        enum:
+        - obligation
+        - license
         example: license
         type: string
       type_id:
         example: 34
         type: integer
+      user:
+        $ref: '#/definitions/models.User'
       user_id:
         example: 123
         type: integer

--- a/pkg/api/licenses.go
+++ b/pkg/api/licenses.go
@@ -561,10 +561,6 @@ func UpdateLicense(c *gin.Context) {
 // addChangelogsForLicenseUpdate adds changelogs for the updated fields on license update
 func addChangelogsForLicenseUpdate(tx *gorm.DB, username string,
 	newLicense, oldLicense *models.LicenseDB) error {
-	var user models.User
-	if err := tx.Where(models.User{Username: username}).First(&user).Error; err != nil {
-		return err
-	}
 	var changes []models.ChangeLog
 
 	if oldLicense.Fullname != newLicense.Fullname {

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -311,14 +311,8 @@ func generateToken(user models.User) (string, error) {
 		return "", err
 	}
 
-	jwtUser := models.JWTUser{
-		Id:        user.Id,
-		Username:  user.Username,
-		Userlevel: user.Userlevel,
-	}
-
 	claims := jwt.MapClaims{}
-	claims["user"] = jwtUser
+	claims["user"] = user
 	claims["nbf"] = time.Now().Unix()
 	claims["exp"] = time.Now().Add(time.Hour * time.Duration(tokenLifespan)).Unix()
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -256,25 +256,18 @@ type User struct {
 	Id           int64   `json:"id" gorm:"primary_key" example:"123"`
 	Username     string  `json:"username" gorm:"unique;not null" binding:"required" example:"fossy"`
 	Userlevel    string  `json:"userlevel" binding:"required" example:"admin"`
-	Userpassword *string `json:"password,omitempty" binding:"required"`
-}
-
-// JWTUser struct is representation of user information in JWT.
-type JWTUser struct {
-	Id        int64  `json:"id"`
-	Username  string `json:"username"`
-	Userlevel string `json:"userlevel"`
+	Userpassword *string `json:"-"`
 }
 
 type UserInput struct {
 	Username     string  `json:"username" gorm:"unique;not null" binding:"required" example:"fossy"`
 	Userlevel    string  `json:"userlevel" binding:"required" example:"admin"`
-	Userpassword *string `json:"password,omitempty" binding:"required"`
+	Userpassword *string `json:"password,omitempty" binding:"required" example:"fossy"`
 }
 
 type UserLogin struct {
 	Username     string `json:"username" binding:"required" example:"fossy"`
-	Userpassword string `json:"password" binding:"required"`
+	Userpassword string `json:"password" binding:"required" example:"fossy"`
 }
 
 // UserResponse struct is representation of design API response of user.

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -296,10 +296,11 @@ type SearchLicense struct {
 type Audit struct {
 	Id         int64       `json:"id" gorm:"primary_key" example:"456"`
 	UserId     int64       `json:"user_id" example:"123"`
-	User       User        `gorm:"foreignKey:UserId;references:Id" json:"-"`
-	TypeId     int64       `json:"type_id" example:"34"`
+	User       User        `gorm:"foreignKey:UserId;references:Id" json:"user"`
 	Timestamp  time.Time   `json:"timestamp" example:"2023-12-01T18:10:25.00+05:30"`
-	Type       string      `json:"type" example:"license"`
+	Type       string      `json:"type" enums:"obligation,license" example:"license"`
+	TypeId     int64       `json:"type_id" example:"34"`
+	Entity     interface{} `json:"entity" gorm:"-" swaggertype:"object"`
 	ChangeLogs []ChangeLog `json:"-"`
 }
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Avinal Kumar <avinal.xlvii@gmail.com>
SPDX-License-Identifier: GPL-2.0-only

Thank you for the pull request. Please fill this template as much as
possible and delete unused parts.
-->

## Changes

<!-- Describe your changes here. Ideally GitHub can get the description
from your descriptive commit message(s). Link issues/PR that are relevant
for your changes.-->

- Adds field 'entity' and 'user' to the Audit Response. Entity can be of type License or Obligation.
- Removes password from user responses
-  Refactor to remove redundant JWTUser struct


## Submitter Checklist

- [ ] Includes tests (if there is a feature changed/added)
- [X] Includes docs ( if changes are user facing)
- [X] I have tested my changes locally.

## References

![image](https://github.com/user-attachments/assets/1b0bb03e-84ba-4ae4-80a1-5b99fd386644)

