### PR TITLE
feat(obligation_classifications): Add admin apis for creating, listing and deleting obligation classifications

### DIFF
--- a/cmd/laas/docs/docs.go
+++ b/cmd/laas/docs/docs.go
@@ -1130,6 +1130,159 @@ const docTemplate = `{
                 }
             }
         },
+        "/obligations/classifications": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Get all active obligation classifications from the service",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Obligations"
+                ],
+                "summary": "Get all active obligation classifications",
+                "operationId": "GetAllObligationClassification",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Active obligation classification only",
+                        "name": "active",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.ObligationClassificationResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "No obligation classifications in DB",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Create an obligation classification",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Obligations"
+                ],
+                "summary": "Create an obligation classification",
+                "operationId": "CreateObligationClassification",
+                "parameters": [
+                    {
+                        "description": "Obligation classification to create",
+                        "name": "obligation_classification",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.ObligationClassification"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.ObligationClassificationResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid json body",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "409": {
+                        "description": "obligation classification already exists",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "500": {
+                        "description": "something went wrong while creating new obligation classification",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    }
+                }
+            }
+        },
+        "/obligations/classifications/{classification}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Deactivate an obligation classification",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Obligations"
+                ],
+                "summary": "Deactivate obligation classification",
+                "operationId": "DeleteObligationClassification",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Obligation Classification",
+                        "name": "classification",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "cannot delete obligation classification 'GREEN' as it's still referenced by some obligations",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "404": {
+                        "description": "obligation classification 'GREEN' not found",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "500": {
+                        "description": "something went wrong while deleting obligation classification",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    }
+                }
+            }
+        },
         "/obligations/export": {
             "get": {
                 "security": [
@@ -1274,8 +1427,7 @@ const docTemplate = `{
             "get": {
                 "security": [
                     {
-                        "ApiKeyAuth": [],
-                        "{}": []
+                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Get all active obligation types from the service",
@@ -1293,7 +1445,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "boolean",
-                        "description": "Active obligation only",
+                        "description": "Active obligation type only",
                         "name": "active",
                         "in": "query",
                         "required": true
@@ -2350,15 +2502,36 @@ const docTemplate = `{
         },
         "models.ObligationClassification": {
             "type": "object",
+            "required": [
+                "classification",
+                "color"
+            ],
             "properties": {
                 "classification": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "GREEN"
                 },
                 "color": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "#00FF00"
+                }
+            }
+        },
+        "models.ObligationClassificationResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.ObligationClassification"
+                    }
                 },
-                "id": {
-                    "type": "integer"
+                "paginationmeta": {
+                    "$ref": "#/definitions/models.PaginationMeta"
+                },
+                "status": {
+                    "type": "integer",
+                    "example": 200
                 }
             }
         },

--- a/cmd/laas/docs/swagger.json
+++ b/cmd/laas/docs/swagger.json
@@ -1123,6 +1123,159 @@
                 }
             }
         },
+        "/obligations/classifications": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Get all active obligation classifications from the service",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Obligations"
+                ],
+                "summary": "Get all active obligation classifications",
+                "operationId": "GetAllObligationClassification",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Active obligation classification only",
+                        "name": "active",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.ObligationClassificationResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "No obligation classifications in DB",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Create an obligation classification",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Obligations"
+                ],
+                "summary": "Create an obligation classification",
+                "operationId": "CreateObligationClassification",
+                "parameters": [
+                    {
+                        "description": "Obligation classification to create",
+                        "name": "obligation_classification",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.ObligationClassification"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.ObligationClassificationResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid json body",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "409": {
+                        "description": "obligation classification already exists",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "500": {
+                        "description": "something went wrong while creating new obligation classification",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    }
+                }
+            }
+        },
+        "/obligations/classifications/{classification}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Deactivate an obligation classification",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Obligations"
+                ],
+                "summary": "Deactivate obligation classification",
+                "operationId": "DeleteObligationClassification",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Obligation Classification",
+                        "name": "classification",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "cannot delete obligation classification 'GREEN' as it's still referenced by some obligations",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "404": {
+                        "description": "obligation classification 'GREEN' not found",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "500": {
+                        "description": "something went wrong while deleting obligation classification",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    }
+                }
+            }
+        },
         "/obligations/export": {
             "get": {
                 "security": [
@@ -1267,8 +1420,7 @@
             "get": {
                 "security": [
                     {
-                        "ApiKeyAuth": [],
-                        "{}": []
+                        "ApiKeyAuth": []
                     }
                 ],
                 "description": "Get all active obligation types from the service",
@@ -1286,7 +1438,7 @@
                 "parameters": [
                     {
                         "type": "boolean",
-                        "description": "Active obligation only",
+                        "description": "Active obligation type only",
                         "name": "active",
                         "in": "query",
                         "required": true
@@ -2343,15 +2495,36 @@
         },
         "models.ObligationClassification": {
             "type": "object",
+            "required": [
+                "classification",
+                "color"
+            ],
             "properties": {
                 "classification": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "GREEN"
                 },
                 "color": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "#00FF00"
+                }
+            }
+        },
+        "models.ObligationClassificationResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.ObligationClassification"
+                    }
                 },
-                "id": {
-                    "type": "integer"
+                "paginationmeta": {
+                    "$ref": "#/definitions/models.PaginationMeta"
+                },
+                "status": {
+                    "type": "integer",
+                    "example": 200
                 }
             }
         },

--- a/cmd/laas/docs/swagger.yaml
+++ b/cmd/laas/docs/swagger.yaml
@@ -362,10 +362,25 @@ definitions:
   models.ObligationClassification:
     properties:
       classification:
+        example: GREEN
         type: string
       color:
+        example: '#00FF00'
         type: string
-      id:
+    required:
+    - classification
+    - color
+    type: object
+  models.ObligationClassificationResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/models.ObligationClassification'
+        type: array
+      paginationmeta:
+        $ref: '#/definitions/models.PaginationMeta'
+      status:
+        example: 200
         type: integer
     type: object
   models.ObligationDTO:
@@ -1497,6 +1512,105 @@ paths:
       summary: Fetches audits corresponding to an obligation
       tags:
       - Obligations
+  /obligations/classifications:
+    get:
+      consumes:
+      - application/json
+      description: Get all active obligation classifications from the service
+      operationId: GetAllObligationClassification
+      parameters:
+      - description: Active obligation classification only
+        in: query
+        name: active
+        required: true
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.ObligationClassificationResponse'
+        "404":
+          description: No obligation classifications in DB
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+      security:
+      - ApiKeyAuth: []
+      summary: Get all active obligation classifications
+      tags:
+      - Obligations
+    post:
+      consumes:
+      - application/json
+      description: Create an obligation classification
+      operationId: CreateObligationClassification
+      parameters:
+      - description: Obligation classification to create
+        in: body
+        name: obligation_classification
+        required: true
+        schema:
+          $ref: '#/definitions/models.ObligationClassification'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/models.ObligationClassificationResponse'
+        "400":
+          description: invalid json body
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+        "409":
+          description: obligation classification already exists
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+        "500":
+          description: something went wrong while creating new obligation classification
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+      security:
+      - ApiKeyAuth: []
+      summary: Create an obligation classification
+      tags:
+      - Obligations
+  /obligations/classifications/{classification}:
+    delete:
+      consumes:
+      - application/json
+      description: Deactivate an obligation classification
+      operationId: DeleteObligationClassification
+      parameters:
+      - description: Obligation Classification
+        in: path
+        name: classification
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: cannot delete obligation classification 'GREEN' as it's still
+            referenced by some obligations
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+        "404":
+          description: obligation classification 'GREEN' not found
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+        "500":
+          description: something went wrong while deleting obligation classification
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+      security:
+      - ApiKeyAuth: []
+      summary: Deactivate obligation classification
+      tags:
+      - Obligations
   /obligations/export:
     get:
       description: Export all obligations as a json file
@@ -1591,7 +1705,7 @@ paths:
       description: Get all active obligation types from the service
       operationId: GetAllObligationType
       parameters:
-      - description: Active obligation only
+      - description: Active obligation type only
         in: query
         name: active
         required: true
@@ -1608,8 +1722,7 @@ paths:
           schema:
             $ref: '#/definitions/models.LicenseError'
       security:
-      - '{}': []
-        ApiKeyAuth: []
+      - ApiKeyAuth: []
       summary: Get all active obligation types
       tags:
       - Obligations

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -136,6 +136,9 @@ func Router() *gin.Engine {
 				obligations.GET("/types", GetAllObligationType)
 				obligations.POST("/types", CreateObligationType)
 				obligations.DELETE("/types/:type", DeleteObligationType)
+				obligations.GET("/classifications", GetAllObligationClassification)
+				obligations.POST("/classifications", CreateObligationClassification)
+				obligations.DELETE("/classifications/:classification", DeleteObligationClassification)
 			}
 			obMap := authorizedv1.Group("/obligation_maps")
 			{
@@ -224,6 +227,9 @@ func Router() *gin.Engine {
 				obligations.GET("/types", GetAllObligationType)
 				obligations.POST("/types", CreateObligationType)
 				obligations.DELETE("/types/:type", DeleteObligationType)
+				obligations.GET("/classifications", GetAllObligationClassification)
+				obligations.POST("/classifications", CreateObligationClassification)
+				obligations.DELETE("/classifications/:classification", DeleteObligationClassification)
 			}
 			obMap := authorizedv1.Group("/obligation_maps")
 			{

--- a/pkg/api/obligationClassifications.go
+++ b/pkg/api/obligationClassifications.go
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: 2024 Siemens AG
+// SPDX-FileContributor: Dearsh Oberoi <dearsh.oberoi@siemens.com>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/fossology/LicenseDb/pkg/db"
+	"github.com/fossology/LicenseDb/pkg/models"
+	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// GetAllObligationClassification retrieves a list of all obligation classifications
+//
+//	@Summary		Get all active obligation classifications
+//	@Description	Get all active obligation classifications from the service
+//	@Id				GetAllObligationClassification
+//	@Tags			Obligations
+//	@Accept			json
+//	@Produce		json
+//	@Param			active	query		bool	true	"Active obligation classification only"
+//	@Success		200		{object}	models.ObligationClassificationResponse
+//	@Failure		404		{object}	models.LicenseError	"No obligation classifications in DB"
+//	@Security		ApiKeyAuth
+//	@Router			/obligations/classifications [get]
+func GetAllObligationClassification(c *gin.Context) {
+	var obligationClassifications []models.ObligationClassification
+	active := c.Query("active")
+	if active == "" {
+		active = "true"
+	}
+	var parsedActive bool
+	parsedActive, err := strconv.ParseBool(active)
+	if err != nil {
+		er := models.LicenseError{
+			Status:    http.StatusBadRequest,
+			Message:   "Invalid active value",
+			Error:     fmt.Sprintf("Parsing failed for value '%s'", active),
+			Path:      c.Request.URL.Path,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		c.JSON(http.StatusBadRequest, er)
+		return
+	}
+
+	query := db.DB.Model(&models.ObligationClassification{})
+	query.Where("active = ?", parsedActive)
+	if err = query.Find(&obligationClassifications).Error; err != nil {
+		er := models.LicenseError{
+			Status:    http.StatusInternalServerError,
+			Message:   "Unable to fetch obligation classifications",
+			Error:     err.Error(),
+			Path:      c.Request.URL.Path,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		c.JSON(http.StatusInternalServerError, er)
+		return
+	}
+
+	res := models.ObligationClassificationResponse{
+		Data:   obligationClassifications,
+		Status: http.StatusOK,
+		Meta: &models.PaginationMeta{
+			ResourceCount: len(obligationClassifications),
+		},
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+// CreateObligationClassification creates a new obligation classification.
+//
+//	@Summary		Create an obligation classification
+//	@Description	Create an obligation classification
+//	@Id				CreateObligationClassification
+//	@Tags			Obligations
+//	@Accept			json
+//	@Produce		json
+//	@Param			obligation_classification	body		models.ObligationClassification	true	"Obligation classification to create"
+//	@Success		201							{object}	models.ObligationClassificationResponse
+//	@Failure		400							{object}	models.LicenseError	"invalid json body"
+//	@Failure		409							{object}	models.LicenseError	"obligation classification already exists"
+//	@Failure		500							{object}	models.LicenseError	"something went wrong while creating new obligation classification"
+//	@Security		ApiKeyAuth
+//	@Router			/obligations/classifications [post]
+func CreateObligationClassification(c *gin.Context) {
+	var obClassification models.ObligationClassification
+	if err := c.ShouldBindJSON(&obClassification); err != nil {
+		er := models.LicenseError{
+			Status:    http.StatusBadRequest,
+			Message:   "invalid json body",
+			Error:     err.Error(),
+			Path:      c.Request.URL.Path,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		c.JSON(http.StatusBadRequest, er)
+		return
+	}
+
+	validate := validator.New(validator.WithRequiredStructEnabled())
+	if err := validate.Struct(&obClassification); err != nil {
+		er := models.LicenseError{
+			Status:    http.StatusBadRequest,
+			Message:   "can not create obligation classification with these field values",
+			Error:     fmt.Sprintf("field '%s' failed validation: %s\n", err.(validator.ValidationErrors)[0].Field(), err.(validator.ValidationErrors)[0].Tag()),
+			Path:      c.Request.URL.Path,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		c.JSON(http.StatusBadRequest, er)
+		return
+	}
+
+	if err := db.DB.Transaction(func(tx *gorm.DB) error {
+		result := tx.Where(&models.ObligationClassification{Classification: obClassification.Classification}).FirstOrCreate(&obClassification)
+		if result.Error != nil {
+			er := models.LicenseError{
+				Status:    http.StatusInternalServerError,
+				Message:   "something went wrong while creating new obligation classification",
+				Error:     result.Error.Error(),
+				Path:      c.Request.URL.Path,
+				Timestamp: time.Now().Format(time.RFC3339),
+			}
+			c.JSON(http.StatusInternalServerError, er)
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			if *obClassification.Active {
+				er := models.LicenseError{
+					Status:    http.StatusConflict,
+					Message:   "obligation classification already exists",
+					Error:     "obligation classification already exists",
+					Path:      c.Request.URL.Path,
+					Timestamp: time.Now().Format(time.RFC3339),
+				}
+				c.JSON(http.StatusConflict, er)
+				return errors.New("obligation classification already exists")
+			}
+			if err := toggleObligationClassificationActiveStatus(c, tx, &obClassification); err != nil {
+				er := models.LicenseError{
+					Status:    http.StatusConflict,
+					Message:   "obligation classification already exists, something went wrong while reactvating it",
+					Error:     err.Error(),
+					Path:      c.Request.URL.Path,
+					Timestamp: time.Now().Format(time.RFC3339),
+				}
+				c.JSON(http.StatusConflict, er)
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		return
+	}
+
+	res := models.ObligationClassificationResponse{
+		Status: http.StatusCreated,
+		Data:   []models.ObligationClassification{obClassification},
+		Meta: &models.PaginationMeta{
+			ResourceCount: 1,
+		},
+	}
+
+	c.JSON(http.StatusCreated, res)
+}
+
+// DeleteObligationClassification marks an existing obligation classification record as inactive
+//
+//	@Summary		Deactivate obligation classification
+//	@Description	Deactivate an obligation classification
+//	@Id				DeleteObligationClassification
+//	@Tags			Obligations
+//	@Accept			json
+//	@Produce		json
+//	@Param			classification	path	string	true	"Obligation Classification"
+//	@Success		200
+//	@Failure		400	{object}	models.LicenseError	"cannot delete obligation classification 'GREEN' as it's still referenced by some obligations"
+//	@Failure		404	{object}	models.LicenseError	"obligation classification 'GREEN' not found"
+//	@Failure		500	{object}	models.LicenseError	"something went wrong while deleting obligation classification"
+//	@Security		ApiKeyAuth
+//	@Router			/obligations/classifications/{classification} [delete]
+func DeleteObligationClassification(c *gin.Context) {
+	var obClassification models.ObligationClassification
+	obClassificationParam := c.Param("classification")
+	if err := db.DB.Where(models.ObligationClassification{Classification: obClassificationParam}).First(&obClassification).Error; err != nil {
+		er := models.LicenseError{
+			Status:    http.StatusNotFound,
+			Message:   fmt.Sprintf("obligation classification '%s' not found", obClassificationParam),
+			Error:     err.Error(),
+			Path:      c.Request.URL.Path,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		c.JSON(http.StatusNotFound, er)
+		return
+	}
+
+	if !*obClassification.Active {
+		c.Status(http.StatusOK)
+		return
+	}
+
+	var count int64
+	if err := db.DB.Model(&models.Obligation{}).Where(&models.Obligation{ObligationClassificationId: obClassification.Id}).Count(&count).Error; err != nil {
+		er := models.LicenseError{
+			Status:    http.StatusInternalServerError,
+			Message:   "something went wrong while deleting obligation classification",
+			Error:     err.Error(),
+			Path:      c.Request.URL.Path,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		c.JSON(http.StatusInternalServerError, er)
+		return
+	}
+
+	if count > 0 {
+		er := models.LicenseError{
+			Status:    http.StatusBadRequest,
+			Message:   fmt.Sprintf("cannot delete obligation classification '%s' as it's still referenced by some obligations", obClassification.Classification),
+			Error:     fmt.Sprintf("cannot delete obligation classification '%s' as it's still referenced by some obligations", obClassification.Classification),
+			Path:      c.Request.URL.Path,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		c.JSON(http.StatusBadRequest, er)
+		return
+	}
+
+	if err := db.DB.Transaction(func(tx *gorm.DB) error {
+		return toggleObligationClassificationActiveStatus(c, tx, &obClassification)
+	}); err != nil {
+		er := models.LicenseError{
+			Status:    http.StatusInternalServerError,
+			Message:   "something went wrong while deleting obligation classification",
+			Error:     err.Error(),
+			Path:      c.Request.URL.Path,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		c.JSON(http.StatusInternalServerError, er)
+	}
+	c.Status(http.StatusOK)
+}
+
+func toggleObligationClassificationActiveStatus(c *gin.Context, tx *gorm.DB, obClassification *models.ObligationClassification) error {
+	*obClassification.Active = !*obClassification.Active
+	if err := tx.Clauses(clause.Returning{}).Updates(&obClassification).Error; err != nil {
+		return errors.New("unable to change 'active' status of obligation classification")
+	}
+
+	username := c.GetString("username")
+	var user models.User
+	if err := tx.Where(models.User{Username: username}).First(&user).Error; err != nil {
+		return errors.New("unable to change 'active' status of obligation classification")
+	}
+
+	oldVal := strconv.FormatBool(!*obClassification.Active)
+	newVal := strconv.FormatBool(*obClassification.Active)
+	change := models.ChangeLog{
+		Field:        "Active",
+		OldValue:     &oldVal,
+		UpdatedValue: &newVal,
+	}
+
+	audit := models.Audit{
+		UserId:     user.Id,
+		TypeId:     obClassification.Id,
+		Timestamp:  time.Now(),
+		Type:       "ObligationClassification",
+		ChangeLogs: []models.ChangeLog{change},
+	}
+
+	if err := tx.Create(&audit).Error; err != nil {
+		return errors.New("unable to change 'active' status of obligation classification")
+	}
+
+	return nil
+}

--- a/pkg/api/obligationTypes.go
+++ b/pkg/api/obligationTypes.go
@@ -28,10 +28,10 @@ import (
 //	@Tags			Obligations
 //	@Accept			json
 //	@Produce		json
-//	@Param			active	query		bool	true	"Active obligation only"
+//	@Param			active	query		bool	true	"Active obligation type only"
 //	@Success		200		{object}	models.ObligationTypeResponse
 //	@Failure		404		{object}	models.LicenseError	"No obligation types in DB"
-//	@Security		ApiKeyAuth || {}
+//	@Security		ApiKeyAuth
 //	@Router			/obligations/types [get]
 func GetAllObligationType(c *gin.Context) {
 	var obligationTypes []models.ObligationType

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -293,10 +293,19 @@ type ObligationTypeResponse struct {
 	Meta   *PaginationMeta  `json:"paginationmeta"`
 }
 
+// ObligationClassification represents one of the possible of obligation classification values
 type ObligationClassification struct {
-	Id             int64  `gorm:"primary_key"`
-	Classification string `gorm:"unique;not null"`
-	Color          string `gorm:"unique; not null"`
+	Id             int64  `gorm:"primary_key" json:"-"`
+	Classification string `gorm:"unique;not null" validate:"required,uppercase" example:"GREEN" json:"classification"`
+	Color          string `gorm:"unique; not null" validate:"required,hexcolor" example:"#00FF00" json:"color"`
+	Active         *bool  `gorm:"not null;default:true" json:"-"`
+}
+
+// ObligationClassificationResponse represents the response format for obligation classification data.
+type ObligationClassificationResponse struct {
+	Status int                        `json:"status" example:"200"`
+	Data   []ObligationClassification `json:"data"`
+	Meta   *PaginationMeta            `json:"paginationmeta"`
 }
 
 // Obligation represents an obligation record in the database.
@@ -359,9 +368,11 @@ func (o *Obligation) BeforeCreate(tx *gorm.DB) (err error) {
 		}
 		allClassifications := ""
 		for i := 0; i < len(obClassifications); i++ {
-			allClassifications += fmt.Sprintf(" %s", obClassifications[i].Classification)
-			if o.Classification.Classification == obClassifications[i].Classification {
-				o.Classification = &obClassifications[i]
+			if *obClassifications[i].Active {
+				allClassifications += fmt.Sprintf(" %s", obClassifications[i].Classification)
+				if o.Classification.Classification == obClassifications[i].Classification {
+					o.Classification = &obClassifications[i]
+				}
 			}
 		}
 		if o.Classification.Id == 0 {
@@ -431,9 +442,11 @@ func (o *Obligation) BeforeUpdate(tx *gorm.DB) (err error) {
 		}
 		allClassifications := ""
 		for i := 0; i < len(obClassifications); i++ {
-			allClassifications += fmt.Sprintf(" %s", obClassifications[i].Classification)
-			if o.Classification.Classification == obClassifications[i].Classification {
-				o.Classification = &obClassifications[i]
+			if *obClassifications[i].Active {
+				allClassifications += fmt.Sprintf(" %s", obClassifications[i].Classification)
+				if o.Classification.Classification == obClassifications[i].Classification {
+					o.Classification = &obClassifications[i]
+				}
 			}
 		}
 		if o.Classification.Id == 0 {

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -459,6 +459,19 @@ func GetAuditEntity(c *gin.Context, audit *models.Audit) error {
 			c.JSON(http.StatusNotFound, er)
 			return err
 		}
+	} else if audit.Type == "obligationClassification" || audit.Type == "ObligationClassification" {
+		audit.Entity = &models.ObligationClassification{}
+		if err := db.DB.Where(&models.ObligationClassification{Id: audit.TypeId}).First(&audit.Entity).Error; err != nil {
+			er := models.LicenseError{
+				Status:    http.StatusNotFound,
+				Message:   "obligation classification corresponding with this audit does not exist",
+				Error:     err.Error(),
+				Path:      c.Request.URL.Path,
+				Timestamp: time.Now().Format(time.RFC3339),
+			}
+			c.JSON(http.StatusNotFound, er)
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Avinal Kumar <avinal.xlvii@gmail.com>
SPDX-License-Identifier: GPL-2.0-only

Thank you for the pull request. Please fill this template as much as
possible and delete unused parts.
-->

## Changes

<!-- Describe your changes here. Ideally GitHub can get the description
from your descriptive commit message(s). Link issues/PR that are relevant
for your changes.-->

- Added admin APIs to create, delete and get a list of obligation classifications.
- POST /obligations/classifications: Creates a new obligation classification if not already present. It must be non-empty and uppercase. If the obligation classifications to be created is already in db with 'active' flag set to false, it is changed to true.
- DELETE /obligation/classifications/{classification}: The {classification} is soft-deleted if it exists in db, has 'active' flag set to true and no obligation references it.
- GET /obligations/classifications: Fetches a list of all obligation classifications. Flag 'active' can be set to false to fetch the inactive classifications.
During obligation creation and updation, associate them with only active obligations.


## Submitter Checklist

- [ ] Includes tests (if there is a feature changed/added)
- [X] Includes docs ( if changes are user facing)
- [X] I have tested my changes locally.

## References

<!-- Add any supporting links/screenshot/logs etc here. If not needed please
delete this block.-->

