### PR TITLE
fix(obligation_apis): Make GET obligation classifications and types unauthorized

### DIFF
--- a/cmd/laas/docs/docs.go
+++ b/cmd/laas/docs/docs.go
@@ -1140,7 +1140,8 @@ const docTemplate = `{
             "get": {
                 "security": [
                     {
-                        "ApiKeyAuth": []
+                        "ApiKeyAuth": [],
+                        "{}": []
                     }
                 ],
                 "description": "Get all active obligation classifications from the service",
@@ -1433,7 +1434,8 @@ const docTemplate = `{
             "get": {
                 "security": [
                     {
-                        "ApiKeyAuth": []
+                        "ApiKeyAuth": [],
+                        "{}": []
                     }
                 ],
                 "description": "Get all active obligation types from the service",

--- a/cmd/laas/docs/swagger.json
+++ b/cmd/laas/docs/swagger.json
@@ -1133,7 +1133,8 @@
             "get": {
                 "security": [
                     {
-                        "ApiKeyAuth": []
+                        "ApiKeyAuth": [],
+                        "{}": []
                     }
                 ],
                 "description": "Get all active obligation classifications from the service",
@@ -1426,7 +1427,8 @@
             "get": {
                 "security": [
                     {
-                        "ApiKeyAuth": []
+                        "ApiKeyAuth": [],
+                        "{}": []
                     }
                 ],
                 "description": "Get all active obligation types from the service",

--- a/cmd/laas/docs/swagger.yaml
+++ b/cmd/laas/docs/swagger.yaml
@@ -1584,7 +1584,8 @@ paths:
           schema:
             $ref: '#/definitions/models.LicenseError'
       security:
-      - ApiKeyAuth: []
+      - '{}': []
+        ApiKeyAuth: []
       summary: Get all active obligation classifications
       tags:
       - Obligations
@@ -1770,7 +1771,8 @@ paths:
           schema:
             $ref: '#/definitions/models.LicenseError'
       security:
-      - ApiKeyAuth: []
+      - '{}': []
+        ApiKeyAuth: []
       summary: Get all active obligation types
       tags:
       - Obligations

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -141,10 +141,10 @@ func Router() *gin.Engine {
 				obligations.POST("import", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), ImportObligations)
 				obligations.PATCH(":topic", UpdateObligation)
 				obligations.DELETE(":topic", DeleteObligation)
-				obligations.GET("/types", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), GetAllObligationType)
+				obligations.GET("/types", GetAllObligationType)
 				obligations.POST("/types", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), CreateObligationType)
 				obligations.DELETE("/types/:type", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), DeleteObligationType)
-				obligations.GET("/classifications", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), GetAllObligationClassification)
+				obligations.GET("/classifications", GetAllObligationClassification)
 				obligations.POST("/classifications", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), CreateObligationClassification)
 				obligations.DELETE("/classifications/:classification", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), DeleteObligationClassification)
 			}
@@ -184,6 +184,8 @@ func Router() *gin.Engine {
 				obligations.GET(":topic", GetObligation)
 				obligations.GET(":topic/audits", GetObligationAudits)
 				obligations.GET("export", ExportObligations)
+				obligations.GET("/types", GetAllObligationType)
+				obligations.GET("/classifications", GetAllObligationClassification)
 			}
 			obMap := unAuthorizedv1.Group("/obligation_maps")
 			{
@@ -240,10 +242,8 @@ func Router() *gin.Engine {
 				obligations.POST("import", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), ImportObligations)
 				obligations.PATCH(":topic", UpdateObligation)
 				obligations.DELETE(":topic", DeleteObligation)
-				obligations.GET("/types", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), GetAllObligationType)
 				obligations.POST("/types", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), CreateObligationType)
 				obligations.DELETE("/types/:type", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), DeleteObligationType)
-				obligations.GET("/classifications", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), GetAllObligationClassification)
 				obligations.POST("/classifications", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), CreateObligationClassification)
 				obligations.DELETE("/classifications/:classification", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), DeleteObligationClassification)
 			}

--- a/pkg/api/obligationClassifications.go
+++ b/pkg/api/obligationClassifications.go
@@ -31,7 +31,7 @@ import (
 //	@Param			active	query		bool	true	"Active obligation classification only"
 //	@Success		200		{object}	models.ObligationClassificationResponse
 //	@Failure		404		{object}	models.LicenseError	"No obligation classifications in DB"
-//	@Security		ApiKeyAuth
+//	@Security		ApiKeyAuth || {}
 //	@Router			/obligations/classifications [get]
 func GetAllObligationClassification(c *gin.Context) {
 	var obligationClassifications []models.ObligationClassification

--- a/pkg/api/obligationTypes.go
+++ b/pkg/api/obligationTypes.go
@@ -31,7 +31,7 @@ import (
 //	@Param			active	query		bool	true	"Active obligation type only"
 //	@Success		200		{object}	models.ObligationTypeResponse
 //	@Failure		404		{object}	models.LicenseError	"No obligation types in DB"
-//	@Security		ApiKeyAuth
+//	@Security		ApiKeyAuth || {}
 //	@Router			/obligations/types [get]
 func GetAllObligationType(c *gin.Context) {
 	var obligationTypes []models.ObligationType


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Avinal Kumar <avinal.xlvii@gmail.com>
SPDX-License-Identifier: GPL-2.0-only

Thank you for the pull request. Please fill this template as much as
possible and delete unused parts.
-->

## Changes

<!-- Describe your changes here. Ideally GitHub can get the description
from your descriptive commit message(s). Link issues/PR that are relevant
for your changes.-->

- The GET obligation types and obligation classifications apis should not be authorized. Only the update, create and delete ones should. These values will be needed in forms for obligation updation/creation.

## Submitter Checklist

- [ ] Includes tests (if there is a feature changed/added)
- [X] Includes docs ( if changes are user facing)
- [X] I have tested my changes locally.

