### PR TITLE
Add missing dependency for env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       DB_NAME: fossology
       POPULATE_DB: true
       GIN_MODE: debug
+    env_file:
+      - .env 
     ports:
       - 8080:8080
     depends_on:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Avinal Kumar <avinal.xlvii@gmail.com>
SPDX-License-Identifier: GPL-2.0-only

Thank you for the pull request. Please fill this template as much as
possible and delete unused parts.
-->

## Changes

<!-- Describe your changes here. Ideally, GitHub can get the description
from your descriptive commit message(s). Link issues/PRs that are relevant
to your changes. -->

- Added `env_file: - .env` to `docker-compose.yml` to ensure the Go application can properly load environment variables.
- Fixes #107.

## Submitter Checklist

- [ ] Includes tests (if there is a feature changed/added).
- [ ] Includes docs (if changes are user-facing).
- [x] I have tested my changes locally.

## References

### After Changes:

When `POPULATE_DB=true`, the error occurs because `Populatedb` is trying to find a `SUPER_ADMIN` user, but the database does not create this user in the Docker environment.

```log
licensedb  | 2025/03/14 14:41:38 /LicenseDb/pkg/utils/util.go:427 record not found
licensedb  | [0.750ms] [rows:0] SELECT * FROM "users" WHERE "users"."userlevel" = 'SUPER_ADMIN' ORDER BY "users"."id" LIMIT 1
licensedb exited with code 1
licensedb  | 2025/03/14 14:41:38 Failed to find a super admin
```


If we set `POPULATE_DB=false`, the application runs successfully:

```log

licensedb  | [GIN-debug] DELETE /api/v1/obligations/types/:type --> github.com/fossology/LicenseDb/pkg/api.DeleteObligationType (7 handlers)
licensedb  | [GIN-debug] POST   /api/v1/obligations/classifications --> github.com/fossology/LicenseDb/pkg/api.CreateObligationClassification (7 handlers)
licensedb  | [GIN-debug] Listening and serving HTTP on :8080
```


### before chnges 
```log
✔ Container licensedb  Recreated 0.1s
Attaching to licensedb, postgres
licensedb  | 2025/03/14 14:48:40 Mandatory environment variables not configured
licensedb exited with code 1
licensedb  | 2025/03/14 14:48:40 Mandatory environment variables not configured
licensedb exited with code 1

```



This PR fixes the issue of loading environment variables in the Docker environment. The Go application does not load the .env file directly when running in Docker, so I have added env_file: - .env in docker-compose.yml to ensure proper loading of environment variables.

For the Populatedb issue, I will create another PR that will either automatically create the SUPER_ADMIN user in the database or set POPULATE_DB to false by default