### PR TITLE
fix(update_license): License update endpoint and it's documentation fixed

### DIFF
--- a/cmd/laas/docs/docs.go
+++ b/cmd/laas/docs/docs.go
@@ -719,6 +719,75 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Update a license in the service",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Licenses"
+                ],
+                "summary": "Update a license",
+                "operationId": "UpdateLicense",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Shortname of the license to be updated",
+                        "name": "shortname",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update license body (requires only the fields to be updated)",
+                        "name": "license",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseUpdateJSONSchema"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "License updated successfully",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid license body",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "404": {
+                        "description": "License with shortname not found",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "409": {
+                        "description": "License with same shortname already exists",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to update license",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    }
+                }
             }
         },
         "/login": {
@@ -2618,6 +2687,98 @@ const docTemplate = `{
                         "GPL-2.0-only",
                         "GPL-2.0-or-later"
                     ]
+                }
+            }
+        },
+        "models.LicenseUpdateJSONSchema": {
+            "type": "object",
+            "properties": {
+                "FSFfree": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "Fedora": {
+                    "type": "string",
+                    "example": "Fedora"
+                },
+                "GPLv2compatible": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "GPLv3compatible": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "OSIapproved": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "active": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "copyleft": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "detector_type": {
+                    "type": "integer",
+                    "maximum": 2,
+                    "minimum": 0,
+                    "example": 1
+                },
+                "external_ref": {
+                    "$ref": "#/definitions/datatypes.JSONType-models_LicenseDBSchemaExtension"
+                },
+                "flag": {
+                    "type": "integer",
+                    "maximum": 2,
+                    "minimum": 0,
+                    "example": 1
+                },
+                "fullname": {
+                    "type": "string",
+                    "example": "MIT License"
+                },
+                "marydone": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "notes": {
+                    "type": "string",
+                    "example": "This license has been superseded."
+                },
+                "obligations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Obligation"
+                    }
+                },
+                "risk": {
+                    "type": "integer",
+                    "maximum": 5,
+                    "minimum": 0,
+                    "example": 1
+                },
+                "source": {
+                    "type": "string",
+                    "example": "Source"
+                },
+                "spdx_id": {
+                    "type": "string",
+                    "example": "MIT"
+                },
+                "text": {
+                    "type": "string",
+                    "example": "MIT License Text here"
+                },
+                "text_updatable": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "url": {
+                    "type": "string",
+                    "example": "https://opensource.org/licenses/MIT"
                 }
             }
         },

--- a/cmd/laas/docs/swagger.json
+++ b/cmd/laas/docs/swagger.json
@@ -712,6 +712,75 @@
                         }
                     }
                 }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Update a license in the service",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Licenses"
+                ],
+                "summary": "Update a license",
+                "operationId": "UpdateLicense",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Shortname of the license to be updated",
+                        "name": "shortname",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update license body (requires only the fields to be updated)",
+                        "name": "license",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseUpdateJSONSchema"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "License updated successfully",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid license body",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "404": {
+                        "description": "License with shortname not found",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "409": {
+                        "description": "License with same shortname already exists",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to update license",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    }
+                }
             }
         },
         "/login": {
@@ -2611,6 +2680,98 @@
                         "GPL-2.0-only",
                         "GPL-2.0-or-later"
                     ]
+                }
+            }
+        },
+        "models.LicenseUpdateJSONSchema": {
+            "type": "object",
+            "properties": {
+                "FSFfree": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "Fedora": {
+                    "type": "string",
+                    "example": "Fedora"
+                },
+                "GPLv2compatible": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "GPLv3compatible": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "OSIapproved": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "active": {
+                    "type": "boolean",
+                    "example": true
+                },
+                "copyleft": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "detector_type": {
+                    "type": "integer",
+                    "maximum": 2,
+                    "minimum": 0,
+                    "example": 1
+                },
+                "external_ref": {
+                    "$ref": "#/definitions/datatypes.JSONType-models_LicenseDBSchemaExtension"
+                },
+                "flag": {
+                    "type": "integer",
+                    "maximum": 2,
+                    "minimum": 0,
+                    "example": 1
+                },
+                "fullname": {
+                    "type": "string",
+                    "example": "MIT License"
+                },
+                "marydone": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "notes": {
+                    "type": "string",
+                    "example": "This license has been superseded."
+                },
+                "obligations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Obligation"
+                    }
+                },
+                "risk": {
+                    "type": "integer",
+                    "maximum": 5,
+                    "minimum": 0,
+                    "example": 1
+                },
+                "source": {
+                    "type": "string",
+                    "example": "Source"
+                },
+                "spdx_id": {
+                    "type": "string",
+                    "example": "MIT"
+                },
+                "text": {
+                    "type": "string",
+                    "example": "MIT License Text here"
+                },
+                "text_updatable": {
+                    "type": "boolean",
+                    "example": false
+                },
+                "url": {
+                    "type": "string",
+                    "example": "https://opensource.org/licenses/MIT"
                 }
             }
         },

--- a/cmd/laas/docs/swagger.yaml
+++ b/cmd/laas/docs/swagger.yaml
@@ -300,6 +300,75 @@ definitions:
           type: string
         type: array
     type: object
+  models.LicenseUpdateJSONSchema:
+    properties:
+      FSFfree:
+        example: false
+        type: boolean
+      Fedora:
+        example: Fedora
+        type: string
+      GPLv2compatible:
+        example: false
+        type: boolean
+      GPLv3compatible:
+        example: false
+        type: boolean
+      OSIapproved:
+        example: false
+        type: boolean
+      active:
+        example: true
+        type: boolean
+      copyleft:
+        example: false
+        type: boolean
+      detector_type:
+        example: 1
+        maximum: 2
+        minimum: 0
+        type: integer
+      external_ref:
+        $ref: '#/definitions/datatypes.JSONType-models_LicenseDBSchemaExtension'
+      flag:
+        example: 1
+        maximum: 2
+        minimum: 0
+        type: integer
+      fullname:
+        example: MIT License
+        type: string
+      marydone:
+        example: false
+        type: boolean
+      notes:
+        example: This license has been superseded.
+        type: string
+      obligations:
+        items:
+          $ref: '#/definitions/models.Obligation'
+        type: array
+      risk:
+        example: 1
+        maximum: 5
+        minimum: 0
+        type: integer
+      source:
+        example: Source
+        type: string
+      spdx_id:
+        example: MIT
+        type: string
+      text:
+        example: MIT License Text here
+        type: string
+      text_updatable:
+        example: false
+        type: boolean
+      url:
+        example: https://opensource.org/licenses/MIT
+        type: string
+    type: object
   models.Obligation:
     properties:
       active:
@@ -1053,6 +1122,51 @@ paths:
       - '{}': []
         ApiKeyAuth: []
       summary: Get a license by shortname
+      tags:
+      - Licenses
+    patch:
+      consumes:
+      - application/json
+      description: Update a license in the service
+      operationId: UpdateLicense
+      parameters:
+      - description: Shortname of the license to be updated
+        in: path
+        name: shortname
+        required: true
+        type: string
+      - description: Update license body (requires only the fields to be updated)
+        in: body
+        name: license
+        required: true
+        schema:
+          $ref: '#/definitions/models.LicenseUpdateJSONSchema'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: License updated successfully
+          schema:
+            $ref: '#/definitions/models.LicenseResponse'
+        "400":
+          description: Invalid license body
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+        "404":
+          description: License with shortname not found
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+        "409":
+          description: License with same shortname already exists
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+        "500":
+          description: Failed to update license
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+      security:
+      - ApiKeyAuth: []
+      summary: Update a license
       tags:
       - Licenses
   /licenses/export:

--- a/pkg/api/licenses.go
+++ b/pkg/api/licenses.go
@@ -348,6 +348,8 @@ func CreateLicense(c *gin.Context) {
 	c.JSON(http.StatusCreated, res)
 }
 
+type ContextKey string
+
 // UpdateLicense Update license with given shortname and create audit and changelog entries.
 //
 //	@Summary		Update a license
@@ -365,8 +367,6 @@ func CreateLicense(c *gin.Context) {
 //	@Failure		500			{object}	models.LicenseError				"Failed to update license"
 //	@Security		ApiKeyAuth
 //	@Router			/licenses/{shortname} [patch]
-type ContextKey string
-
 func UpdateLicense(c *gin.Context) {
 	_ = db.DB.Transaction(func(tx *gorm.DB) error {
 		var updates models.LicenseUpdateJSONSchema

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -92,12 +92,13 @@ func validateLicenseFields(l *LicenseDB) error {
 	if l.Text != nil && *l.Text == "" {
 		return errors.New("text cannot be an empty string")
 	}
-	if l.SpdxId != nil && *l.SpdxId == "" {
-		return errors.New("spdx_id cannot be an empty string")
-	} else {
-		valid, _ := spdxexp.ValidateLicenses([]string{*l.SpdxId})
-		if !valid {
-			return errors.New("spdx_id does not follow spdx license expression specifications")
+	if l.SpdxId != nil {
+		if *l.SpdxId == "" {
+			return errors.New("spdx_id cannot be an empty string")
+		} else {
+			if valid, _ := spdxexp.ValidateLicenses([]string{*l.SpdxId}); !valid {
+				return errors.New("spdx_id does not follow spdx license expression specifications")
+			}
 		}
 	}
 	if l.Risk != nil && (*l.Risk < 0 || *l.Risk > 5) {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Avinal Kumar <avinal.xlvii@gmail.com>
SPDX-License-Identifier: GPL-2.0-only

Thank you for the pull request. Please fill this template as much as
possible and delete unused parts.
-->

## Changes

<!-- Describe your changes here. Ideally GitHub can get the description
from your descriptive commit message(s). Link issues/PR that are relevant
for your changes.-->

- Swagger documentation was not being detected because of variable declaration before function and after comments for swagger docs.
- The ```validateLicenseFields``` function was called even when the key value for spdx_id in payload was undefined in ```BeforeUpdate``` hook of licenses, causing nil dereference error.
- Closes #109 

## Submitter Checklist

- [ ] Includes tests (if there is a feature changed/added)
- [X] Includes docs ( if changes are user facing)
- [X] I have tested my changes locally.

