### PR TITLE
fix(license_export): optimize schema export for better performance and consistency

### DIFF
--- a/cmd/laas/docs/docs.go
+++ b/cmd/laas/docs/docs.go
@@ -2499,6 +2499,14 @@ const docTemplate = `{
                 "copyleft": {
                     "type": "boolean"
                 },
+                "created_by": {
+                    "description": "Reference to User",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.User"
+                        }
+                    ]
+                },
                 "detector_type": {
                     "type": "integer",
                     "maximum": 2,
@@ -2524,12 +2532,6 @@ const docTemplate = `{
                 "notes": {
                     "type": "string",
                     "example": "This license has been superseded."
-                },
-                "obligations": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Obligation"
-                    }
                 },
                 "risk": {
                     "type": "integer",
@@ -2557,14 +2559,6 @@ const docTemplate = `{
                 "url": {
                     "type": "string",
                     "example": "https://opensource.org/licenses/MIT"
-                },
-                "user": {
-                    "description": "Reference to User",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/models.User"
-                        }
-                    ]
                 }
             }
         },

--- a/cmd/laas/docs/swagger.json
+++ b/cmd/laas/docs/swagger.json
@@ -2492,6 +2492,14 @@
                 "copyleft": {
                     "type": "boolean"
                 },
+                "created_by": {
+                    "description": "Reference to User",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/models.User"
+                        }
+                    ]
+                },
                 "detector_type": {
                     "type": "integer",
                     "maximum": 2,
@@ -2517,12 +2525,6 @@
                 "notes": {
                     "type": "string",
                     "example": "This license has been superseded."
-                },
-                "obligations": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Obligation"
-                    }
                 },
                 "risk": {
                     "type": "integer",
@@ -2550,14 +2552,6 @@
                 "url": {
                     "type": "string",
                     "example": "https://opensource.org/licenses/MIT"
-                },
-                "user": {
-                    "description": "Reference to User",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/models.User"
-                        }
-                    ]
                 }
             }
         },

--- a/cmd/laas/docs/swagger.yaml
+++ b/cmd/laas/docs/swagger.yaml
@@ -163,6 +163,10 @@ definitions:
         type: string
       copyleft:
         type: boolean
+      created_by:
+        allOf:
+        - $ref: '#/definitions/models.User'
+        description: Reference to User
       detector_type:
         example: 1
         maximum: 2
@@ -183,10 +187,6 @@ definitions:
       notes:
         example: This license has been superseded.
         type: string
-      obligations:
-        items:
-          $ref: '#/definitions/models.Obligation'
-        type: array
       risk:
         maximum: 5
         minimum: 0
@@ -207,10 +207,6 @@ definitions:
       url:
         example: https://opensource.org/licenses/MIT
         type: string
-      user:
-        allOf:
-        - $ref: '#/definitions/models.User'
-        description: Reference to User
     required:
     - fullname
     - shortname

--- a/pkg/api/licenses.go
+++ b/pkg/api/licenses.go
@@ -722,7 +722,7 @@ func ImportLicenses(c *gin.Context) {
 //	@Router			/licenses/export [get]
 func ExportLicenses(c *gin.Context) {
 	var licenses []models.LicenseDB
-	query := db.DB.Model(&models.LicenseDB{})
+	query := db.DB.Model(&models.LicenseDB{}).Preload("User")
 	err := query.Find(&licenses).Error
 	if err != nil {
 		er := models.LicenseError{

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -48,9 +48,9 @@ type LicenseDB struct {
 	Flag            *int64                                       `json:"flag" gorm:"default:1;column:rf_flag;not null;default:0" validate:"omitempty,min=0,max=2" example:"1"`
 	Marydone        *bool                                        `json:"marydone" gorm:"column:marydone;not null;default:false"`
 	ExternalRef     datatypes.JSONType[LicenseDBSchemaExtension] `json:"external_ref"`
-	Obligations     []*Obligation                                `gorm:"many2many:obligation_licenses;" json:"obligations"`
-	UserId          int64                                        `json:"-" example:"123"`                             // Foreign key to User
-	User            User                                         `gorm:"foreignKey:UserId;references:Id" json:"user"` // Reference to User
+	Obligations     []*Obligation                                `gorm:"many2many:obligation_licenses;" json:"-"`
+	UserId          int64                                        `json:"-" example:"123"`                                   // Foreign key to User
+	User            User                                         `gorm:"foreignKey:UserId;references:Id" json:"created_by"` // Reference to User
 }
 
 // BeforeCreate hook to validate data and log the user who is creating the record


### PR DESCRIPTION

- Exclude unnecessary fields from the export/get-licenses
- Improve data export format

Closes #111, #112

<!--
SPDX-FileCopyrightText: 2024 Avinal Kumar <avinal.xlvii@gmail.com>
SPDX-License-Identifier: GPL-2.0-only

Thank you for the pull request. Please fill this template as much as
possible and delete unused parts.
-->

##  **Changes**
- Preloaded `USER` in the `export licenses` response.
- Removed `Obligations` from the JSON response.
- Renamed `user` to `created_by` at json response for better readability.

---



## Submitter Checklist

- [X] Includes tests (if there is a feature changed/added)
- [X] Includes docs ( if changes are user facing)
- [X] I have tested my changes locally.

## References
- export response 
![image](https://github.com/user-attachments/assets/b342a830-df1b-49e3-b808-47cfb97c36ec)

- get licenses response


![Screenshot from 2025-03-21 02-31-36](https://github.com/user-attachments/assets/db1ff37a-3a81-44d1-befb-be10a2eaa6e0)



##  **Note**
After reviewing the full database, this schema is not used directly anywhere. Therefore, these modifications will not introduce breaking changes.  
Additionally, renaming `UserId` to `CreatorId` improves readability for
 create-license api and also in database .


