### PR TITLE
fix(obligations): align Swagger docs with existing implementation for obligations endpoint

### DIFF
--- a/cmd/laas/docs/docs.go
+++ b/cmd/laas/docs/docs.go
@@ -1107,8 +1107,14 @@ const docTemplate = `{
                             "$ref": "#/definitions/models.SwaggerObligationResponse"
                         }
                     },
-                    "404": {
-                        "description": "No obligations in DB",
+                    "400": {
+                        "description": "Invalid active value",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/models.LicenseError"
                         }

--- a/cmd/laas/docs/swagger.json
+++ b/cmd/laas/docs/swagger.json
@@ -1100,8 +1100,14 @@
                             "$ref": "#/definitions/models.SwaggerObligationResponse"
                         }
                     },
-                    "404": {
-                        "description": "No obligations in DB",
+                    "400": {
+                        "description": "Invalid active value",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
                         "schema": {
                             "$ref": "#/definitions/models.LicenseError"
                         }

--- a/cmd/laas/docs/swagger.yaml
+++ b/cmd/laas/docs/swagger.yaml
@@ -1468,8 +1468,12 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/models.SwaggerObligationResponse'
-        "404":
-          description: No obligations in DB
+        "400":
+          description: Invalid active value
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+        "500":
+          description: Internal server error
           schema:
             $ref: '#/definitions/models.LicenseError'
       security:

--- a/pkg/api/obligations.go
+++ b/pkg/api/obligations.go
@@ -40,7 +40,8 @@ import (
 //	@Param			limit		query		int		false	"Number of records per page"
 //	@Param			order_by	query		string	false	"Asc or desc ordering"	Enums(asc, desc)	default(asc)
 //	@Success		200			{object}	models.SwaggerObligationResponse
-//	@Failure		404			{object}	models.LicenseError	"No obligations in DB"
+//	@Failure		400			{object}	models.LicenseError	"Invalid active value"
+//	@Failure		500			{object}	models.LicenseError	"Internal server error"
 //	@Security		ApiKeyAuth || {}
 //	@Router			/obligations [get]
 func GetAllObligation(c *gin.Context) {


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: 2024 Avinal Kumar <avinal.xlvii@gmail.com>
SPDX-License-Identifier: GPL-2.0-only

Thank you for the pull request. Please fill this template as much as
possible and delete unused parts.
-->
## Changes

- Updated the Swagger documentation to:
  - Remove the incorrect 404 response
  - Add missing 400 and 500 response documentation to match implementation
- Fixes #119 


## Submitter Checklist

- [x] Includes tests (if there is a feature changed/added)
- [x] Includes docs ( if changes are user facing)
- [x] I have tested my changes locally.



