### PR TITLE
fix(obligation_creation): pass user name in context for the db call w…

### DIFF
--- a/pkg/api/obligations.go
+++ b/pkg/api/obligations.go
@@ -167,7 +167,10 @@ func CreateObligation(c *gin.Context) {
 		return
 	}
 
-	result := db.DB.
+	username := c.GetString("username")
+	ctx := context.WithValue(context.Background(), models.ContextKey("user"), username)
+
+	result := db.DB.WithContext(ctx)
 		Where(&models.Obligation{Topic: obligation.Topic}).
 		Or(&models.Obligation{Md5: obligation.Md5}).
 		FirstOrCreate(&obligation)


### PR DESCRIPTION
…hile creating obligations
## Changes
As mentioned in the associated issue we were getting the following error:
`username not found in context`. This was due to the hook we had in our license model. 
```go
func (l *LicenseDB) BeforeCreate(tx *gorm.DB) error {
	username, ok := tx.Statement.Context.Value(ContextKey("user")).(string)
	if !ok {
		return errors.New("username not found in context")
	}
	...
}
```

Now since we were not passing the user in the context, we were unable to figure out the username and hence we were getting the error.
- Fixes #121 
With this fix we can create obligations with shortnames attached.

## Submitter Checklist

- [x] Includes tests (if there is a feature changed/added)
- [x] Includes docs ( if changes are user facing) [Nothing changes for the end user]
- [x] I have tested my changes locally.

## References

<img width="1081" alt="Screenshot 2025-03-25 at 3 54 49 PM" src="https://github.com/user-attachments/assets/66b49804-323e-49ef-9644-800d55715ddb" />

