### PR TITLE
fix:similarity api sometimes used the default threshold

### DIFF
--- a/cmd/laas/main.go
+++ b/cmd/laas/main.go
@@ -69,7 +69,6 @@ func main() {
 	if *populatedb {
 		utils.Populatedb(*datafile)
 	}
-	utils.SetSimilarityThreshold() // Set the similarity threshold from the environment variable
 
 	r := api.Router()
 

--- a/pkg/api/licenses.go
+++ b/pkg/api/licenses.go
@@ -848,6 +848,7 @@ func getSimilarLicenses(c *gin.Context) {
 		return
 	}
 	var results []models.SimilarLicense
+	utils.SetSimilarityThreshold()
 	query := `
 		SELECT rf_id, rf_shortname, rf_text, similarity(rf_text, ?) AS similarity
 		FROM license_dbs

--- a/pkg/api/obligations.go
+++ b/pkg/api/obligations.go
@@ -788,6 +788,7 @@ func getSimilarObligations(c *gin.Context) {
 		return
 	}
 	var results []models.SimilarObligation
+	utils.SetSimilarityThreshold()
 	rawQuery := `
 		SELECT id, topic,text, similarity(text, ?) AS similarity
 		FROM obligations


### PR DESCRIPTION
- due to gorm , the database connection does not use the same connection everytime, it may create another connection(session) before query, where the threshold value is not set(so it gives a result with default 0.3 threshold) ...  so before every connection for similarity search has to set the threshold ..


@deo002 
