### PR TITLE
refactor(laas): convert schema generator logging to structured zap logger

### DIFF
--- a/cmd/laas/gen_external_ref_schema.go
+++ b/cmd/laas/gen_external_ref_schema.go
@@ -10,12 +10,13 @@ package main
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 
 	"path/filepath"
 
 	"github.com/dave/jennifer/jen"
+	logger "github.com/fossology/LicenseDb/pkg/log"
+	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 )
 
@@ -41,12 +42,12 @@ func main() {
 
 	fieldsMetadata, err := os.ReadFile(PATH_EXTERNAL_REF_CONFIG_FILE)
 	if err != nil {
-		log.Fatalf("Failed to instantiate json schema for external ref in license: %v", err)
+		logger.LogFatal("Failed to instantiate json schema for external ref in license", zap.Error(err))
 	}
 
 	err = yaml.Unmarshal(fieldsMetadata, &externalRefFields)
 	if err != nil {
-		log.Fatalf("Failed to instantiate json schema for external ref in license: %v", err)
+		logger.LogFatal("Failed to instantiate json schema for external ref in license", zap.Error(err))
 	}
 
 	// REUSE-IgnoreStart
@@ -74,7 +75,7 @@ func main() {
 			err = fmt.Errorf("type %s in external_ref_fields.yaml is not supported", f.Type)
 		}
 		if err != nil {
-			log.Fatalf("Failed to instantiate json schema for external ref in license: %v", err)
+			logger.LogFatal("Failed to instantiate json schema for external ref in license", zap.Error(err))
 			return
 		}
 		field = field.Tag(map[string]string{"json": fmt.Sprintf("%s,omitempty", f.Name), "swaggerignore": "true"})


### PR DESCRIPTION
This change refactors logging in cmd/laas/gen_external_ref_schema.go by replacing standard log calls with structured Zap logging for error handling and fatal exits.