### PR TITLE
fix(refresh_token_claim_type): fix the sub  type at refresh token claims

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -1109,7 +1109,7 @@ func generateToken(user models.User) (*models.Tokens, error) {
 		IssuedAt(now).
 		NotBefore(now).
 		Expiration(now.Add(time.Hour*time.Duration(refreshTokenLifespan))).
-		Claim("sub", fmt.Sprintf("%d", user.Id)).
+		Claim("sub", user.Id.String()).
 		Claim("type", "refresh").
 		Claim("user", safeClaim).
 		Build()


### PR DESCRIPTION
## Description

This PR updates the refresh-token subject (`sub`) claim to correctly use the new UUID-based user ID type.

Previously, the user ID was an integer,


error 
```

{"level":"info","ts":1767695420.3332064,"caller":"auth/auth.go:952","msg":"VerifyRefreshToken called"}
{"level":"error","ts":1767695420.3336425,"caller":"auth/auth.go:1012","msg":"Invalid user ID in token","error":"invalid UUID length: 61","sub":"[114 179 104 46 105 137 70 177 177 207 16 98 227 142 123 127]"}

```