### PR TITLE
feat(ci): add new ci for commit format checking

### DIFF
--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 Vishesh Gupta <vishesh15th@gmail.com>
+# SPDX-License-Identifier: GPL-2.0-only
+
+name: Commit Message & DCO Check
+
+on:
+  pull_request:
+
+jobs:
+  lint-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Ensure Commit-Lint Config Exists
+        run: |
+          if [ ! -f "commitlint.config.mjs" ]; then
+            echo "module.exports = { extends: ['@commitlint/config-conventional'] };" > commitlint.config.mjs
+          fi
+
+      - name: Run Commit Lint
+        uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: ./commitlint.config.mjs
+
+      - name: DCO Check
+        uses: christophebedard/dco-check@0.5.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --exclude-pattern '.*dependabot\[bot\]@users\.noreply\.github\.com'

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2026 Vishesh Gupta <vishesh15th@gmail.com>
+// SPDX-License-Identifier: GPL-2.0-only
+export default {
+  extends: ["@commitlint/config-conventional"],
+};


### PR DESCRIPTION


issue#182 

## Changes

- Added a GitHub Actions workflow to validate commit messages on pull requests
- Enforces the existing commit message convention:
  `<type>(<scope>): <subject>`
- Ignores auto-generated merge commits created by GitHub during PR checks
- Ensures only human-authored commits are validated

### Example of a valid commit message
```
ci(github-actions): enforce commit message convention on pull requests
```
## Submitter Checklist

- [ ] Includes tests (if there is a feature changed/added)
- [ ] Includes docs ( if changes are user facing)
- [x] I have tested my changes locally.
