### PR TITLE
refactor(test): use structured zap logging in obligationClassifications_test.go

### DIFF
--- a/tests/obligationClassifications_test.go
+++ b/tests/obligationClassifications_test.go
@@ -6,7 +6,6 @@ package test
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 	"testing"
 
@@ -59,7 +58,7 @@ func TestGetAllObligationClassification(t *testing.T) {
 	t.Run("successWithActiveTrue", func(t *testing.T) {
 		w := makeRequest("GET", "/obligations/classifications?active=true", nil, true)
 		assert.Equal(t, http.StatusOK, w.Code)
-		log.Printf("%v", w.Body)
+
 		var res models.ObligationClassificationResponse
 		err := json.Unmarshal(w.Body.Bytes(), &res)
 		assert.NoError(t, err)


### PR DESCRIPTION
This PR refactors test logging to use structured Zap logs instead of the standard log package for file obligationClassifications_test.go