### PR TITLE
refactor: replace log with zap logger (Issue #168)

### DIFF
--- a/cmd/laas/gen_external_ref_schema.go
+++ b/cmd/laas/gen_external_ref_schema.go
@@ -10,10 +10,11 @@ package main
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 
 	"path/filepath"
+
+	logger "github.com/fossology/LicenseDb/pkg/log"
 
 	"github.com/dave/jennifer/jen"
 	"gopkg.in/yaml.v3"
@@ -41,12 +42,12 @@ func main() {
 
 	fieldsMetadata, err := os.ReadFile(PATH_EXTERNAL_REF_CONFIG_FILE)
 	if err != nil {
-		log.Fatalf("Failed to instantiate json schema for external ref in license: %v", err)
+		logger.LogFatal(fmt.Sprintf("Failed to instantiate json schema for external ref in license: %v", err))
 	}
 
 	err = yaml.Unmarshal(fieldsMetadata, &externalRefFields)
 	if err != nil {
-		log.Fatalf("Failed to instantiate json schema for external ref in license: %v", err)
+		logger.LogFatal(fmt.Sprintf("Failed to instantiate json schema for external ref in license: %v", err))
 	}
 
 	// REUSE-IgnoreStart
@@ -74,7 +75,7 @@ func main() {
 			err = fmt.Errorf("type %s in external_ref_fields.yaml is not supported", f.Type)
 		}
 		if err != nil {
-			log.Fatalf("Failed to instantiate json schema for external ref in license: %v", err)
+			logger.LogFatal(fmt.Sprintf("Failed to instantiate json schema for external ref in license: %v", err))
 			return
 		}
 		field = field.Tag(map[string]string{"json": fmt.Sprintf("%s,omitempty", f.Name), "swaggerignore": "true"})

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"html"
-	"log"
 	"net/http"
 	"os"
 	"strconv"
@@ -176,7 +175,7 @@ func CreateOidcUser(c *gin.Context) {
 			Timestamp: time.Now().Format(time.RFC3339),
 		}
 		c.JSON(http.StatusInternalServerError, er)
-		log.Print("\033[31mError: OIDC environment variables not configured properly\033[0m")
+		logger.LogError("Error: OIDC environment variables not configured properly")
 		return
 	}
 
@@ -213,7 +212,7 @@ func CreateOidcUser(c *gin.Context) {
 
 	keyset, err := Jwks.Lookup(context.Background(), os.Getenv("JWKS_URI"))
 	if err != nil {
-		log.Print("\033[31mError: Failed jwk.Cache lookup from the oidc provider's URL\033[0m")
+		logger.LogError("Error: Failed jwk.Cache lookup from the oidc provider's URL")
 		er := models.LicenseError{
 			Status:    http.StatusInternalServerError,
 			Message:   "Something went wrong",
@@ -242,7 +241,7 @@ func CreateOidcUser(c *gin.Context) {
 	}
 
 	if keyError {
-		log.Printf("\033[31mError: Token verification failed due to invalid alg header key field \033[0m")
+		logger.LogError("Error: Token verification failed due to invalid alg header key field")
 		er := models.LicenseError{
 			Status:    http.StatusUnauthorized,
 			Message:   "Please check your credentials and try again",
@@ -263,7 +262,7 @@ func CreateOidcUser(c *gin.Context) {
 			Timestamp: time.Now().Format(time.RFC3339),
 		}
 		c.JSON(http.StatusUnauthorized, er)
-		log.Printf("\033[31mError: Token verification failed \033[0m")
+		logger.LogError("Error: Token verification failed")
 		return
 	}
 
@@ -290,7 +289,7 @@ func CreateOidcUser(c *gin.Context) {
 			Timestamp: time.Now().Format(time.RFC3339),
 		}
 		c.JSON(http.StatusUnauthorized, er)
-		log.Printf("\033[31mError: Issuer '%s' not supported\033[0m", iss)
+		logger.LogError(fmt.Sprintf("Error: Issuer '%s' not supported", iss))
 		return
 	}
 
@@ -313,7 +312,7 @@ func CreateOidcUser(c *gin.Context) {
 			Timestamp: time.Now().Format(time.RFC3339),
 		}
 		c.JSON(http.StatusUnauthorized, er)
-		log.Printf("\033[31mError: %s\033[0m", errMessage)
+		logger.LogError(fmt.Sprintf("Error: %s", errMessage))
 		return
 	}
 	level := "USER"

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"reflect"
@@ -20,18 +19,17 @@ import (
 	"strings"
 	"time"
 
-	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
-
-	"golang.org/x/crypto/bcrypt"
-
+	"github.com/fossology/LicenseDb/pkg/db"
+	logger "github.com/fossology/LicenseDb/pkg/log"
+	"github.com/fossology/LicenseDb/pkg/models"
+	"github.com/fossology/LicenseDb/pkg/validations"
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
 	"github.com/google/uuid"
-
-	"github.com/fossology/LicenseDb/pkg/db"
-	"github.com/fossology/LicenseDb/pkg/models"
-	"github.com/fossology/LicenseDb/pkg/validations"
+	"go.uber.org/zap"
+	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 var (
@@ -205,13 +203,9 @@ func InsertOrUpdateLicenseOnImport(lic *models.LicenseImportDTO, userId uuid.UUI
 		} else if lic.Shortname != nil {
 			erroredElem = *lic.Shortname
 		}
-		red := "\033[31m"
-		reset := "\033[0m"
-		log.Printf("%s%s: %s%s", red, erroredElem, message, reset)
+		logger.LogError(fmt.Sprintf("%s: %s", erroredElem, message))
 	} else {
-		green := "\033[32m"
-		reset := "\033[0m"
-		log.Printf("%sImport for license '%s' successful%s", green, (*lic.Id).String(), reset)
+		logger.LogInfo(fmt.Sprintf("Import for license '%s' successful", (*lic.Id).String()))
 	}
 	return message, importStatus
 }
@@ -504,25 +498,23 @@ func Populatedb(datafile string) {
 	// Read the content of the data file.
 	byteResult, err := os.ReadFile(datafile)
 	if err != nil {
-		log.Fatalf("Unable to read JSON file: %v", err)
+		logger.LogFatal("Unable to read JSON file", zap.Error(err))
 	}
 	// Unmarshal the JSON file data into a slice of LicenseJson structs.
 	if err := json.Unmarshal(byteResult, &licenses); err != nil {
-		log.Fatalf("error reading from json file: %v", err)
+		logger.LogFatal("error reading from json file", zap.Error(err))
 	}
 
 	user := models.User{}
 	level := "SUPER_ADMIN"
 	if err := db.DB.Where(&models.User{UserLevel: &level}).First(&user).Error; err != nil {
-		log.Fatalf("Failed to find a super admin")
+		logger.LogFatal("Failed to find a super admin")
 	}
 
 	for _, license := range licenses {
 		result := license.Converter()
 		if err := validations.Validate.Struct(&result); err != nil {
-			red := "\033[31m"
-			reset := "\033[0m"
-			log.Printf("%s%s: %s%s", red, *result.Shortname, fmt.Sprintf("field '%s' failed validation: %s\n", err.(validator.ValidationErrors)[0].Field(), err.(validator.ValidationErrors)[0].Tag()), reset)
+			logger.LogError(fmt.Sprintf("%s: field '%s' failed validation: %s", *result.Shortname, err.(validator.ValidationErrors)[0].Field(), err.(validator.ValidationErrors)[0].Tag()))
 			continue
 		}
 		_, _ = InsertOrUpdateLicenseOnImport(&result, user.Id)
@@ -539,13 +531,9 @@ func Populatedb(datafile string) {
 		err, status := CreateObType(obType, user.Id)
 
 		if status == CREATED || status == CONFLICT {
-			green := "\033[32m"
-			reset := "\033[0m"
-			log.Printf("%s%s: %s%s", green, obType.Type, "Obligation type created successfully", reset)
+			logger.LogInfo(fmt.Sprintf("%s: Obligation type created successfully", obType.Type))
 		} else {
-			red := "\033[31m"
-			reset := "\033[0m"
-			log.Printf("%s%s: %s%s", red, obType.Type, err.Error(), reset)
+			logger.LogError(fmt.Sprintf("%s: %s", obType.Type, err.Error()))
 		}
 	}
 
@@ -560,13 +548,9 @@ func Populatedb(datafile string) {
 		err, status := CreateObClassification(obClassification, user.Id)
 
 		if status == CREATED || status == CONFLICT {
-			green := "\033[32m"
-			reset := "\033[0m"
-			log.Printf("%s%s: %s%s", green, obClassification.Classification, "Obligation classification created successfully", reset)
+			logger.LogInfo(fmt.Sprintf("%s: Obligation classification created successfully", obClassification.Classification))
 		} else {
-			red := "\033[31m"
-			reset := "\033[0m"
-			log.Printf("%s%s: %s%s", red, obClassification.Classification, err.Error(), reset)
+			logger.LogError(fmt.Sprintf("%s: %s", obClassification.Classification, err.Error()))
 		}
 	}
 }
@@ -581,15 +565,15 @@ func SetSimilarityThreshold() {
 		if parsed, err := strconv.ParseFloat(thresholdStr, 64); err == nil {
 			threshold = parsed
 		} else {
-			log.Printf("Invalid SIMILARITY_THRESHOLD '%s', using default %.1f", thresholdStr, defaultThreshold)
+			logger.LogWarn(fmt.Sprintf("Invalid SIMILARITY_THRESHOLD '%s', using default %.1f", thresholdStr, defaultThreshold))
 		}
 	} else {
-		log.Printf("SIMILARITY_THRESHOLD not set, using default %.1f", defaultThreshold)
+		logger.LogInfo(fmt.Sprintf("SIMILARITY_THRESHOLD not set, using default %.1f", defaultThreshold))
 	}
 
 	query := fmt.Sprintf("SET pg_trgm.similarity_threshold = %f", threshold)
 	if err := db.DB.Exec(query).Error; err != nil {
-		log.Println("Failed to set similarity threshold:", err)
+		logger.LogError("Failed to set similarity threshold", zap.Error(err))
 	}
 }
 

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -9,16 +9,17 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http/httptest"
 	"os"
 	"testing"
 
 	"github.com/fossology/LicenseDb/pkg/api"
 	"github.com/fossology/LicenseDb/pkg/db"
+	logger "github.com/fossology/LicenseDb/pkg/log"
 	"github.com/fossology/LicenseDb/pkg/models"
 	"github.com/fossology/LicenseDb/pkg/utils"
 	"github.com/fossology/LicenseDb/pkg/validations"
+	"go.uber.org/zap"
 	"github.com/gin-gonic/gin"
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
@@ -39,7 +40,7 @@ func TestMain(m *testing.M) {
 
 	err := godotenv.Load(envFile)
 	if err != nil {
-		log.Fatalf("Error loading .env file: %v", err)
+		logger.LogFatal("Error loading .env file", zap.Error(err))
 	}
 	dbname := os.Getenv("DB_NAME")
 	user := os.Getenv("DB_USER")
@@ -51,11 +52,11 @@ func TestMain(m *testing.M) {
 	runMigrations(user, password, port, dbhost, dbname)   // migrate the test db
 	db.Connect(&dbhost, &port, &user, &dbname, &password) // connnect to the test db
 	if err := seedFirstUser(); err != nil {               // create fisrt user to the test db
-		log.Fatalf(" Failed to seed user: %v", err)
+		logger.LogFatal("Failed to seed user", zap.Error(err))
 	}
-	log.Println("First user created")
+	logger.LogInfo("First user created")
 	if err := validations.RegisterValidations(); err != nil {
-		log.Fatalf("Failed to set up validations: %s", err)
+		logger.LogFatal(fmt.Sprintf("Failed to set up validations: %s", err))
 	}
 	utils.Populatedb(testDataFile) // populate the nessesary tables with data from the file
 	serverPort := os.Getenv("PORT")
@@ -98,16 +99,16 @@ func createTestDB(user, password, port, host, dbname string) {
 	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=postgres sslmode=disable", host, port, user, password)
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
-		log.Fatalf(" Failed to connect to postgres: %v", err)
+		logger.LogFatal(fmt.Sprintf("Failed to connect to postgres: %v", err))
 	}
 	defer db.Close()
 
 	_, err = db.Exec("CREATE DATABASE " + dbname)
 	if err != nil && !isAlreadyExistsError(err) {
-		log.Fatalf(" Failed to create test DB: %v", err)
+		logger.LogFatal(fmt.Sprintf("Failed to create test DB: %v", err))
 	}
 
-	log.Println(" Test DB created")
+	logger.LogInfo("Test DB created")
 }
 
 func isAlreadyExistsError(err error) bool {
@@ -122,14 +123,14 @@ func runMigrations(user, password, port, host, dbname string) {
 		dsn,
 	)
 	if err != nil {
-		log.Fatalf(" Failed to create migration instance: %v", err)
+		logger.LogFatal(fmt.Sprintf("Failed to create migration instance: %v", err))
 	}
 
 	if err := m.Up(); err != nil && err != migrate.ErrNoChange {
-		log.Fatalf(" Migration failed: %v", err)
+		logger.LogFatal(fmt.Sprintf("Migration failed: %v", err))
 	}
 
-	log.Println("Migrations applied")
+	logger.LogInfo("Migrations applied")
 }
 
 func seedFirstUser() error {
@@ -172,7 +173,7 @@ func dropTestDB(user, password, port, host, dbname string) {
 	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=postgres sslmode=disable", host, port, user, password)
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
-		log.Printf(" Error opening connection to drop DB: %v", err)
+		logger.LogInfo(fmt.Sprintf("Error opening connection to drop DB: %v", err))
 		return
 	}
 	defer db.Close()
@@ -182,8 +183,8 @@ func dropTestDB(user, password, port, host, dbname string) {
 
 	_, err = db.Exec("DROP DATABASE IF EXISTS " + dbname)
 	if err != nil {
-		log.Printf(" Error dropping test DB: %v", err)
+		logger.LogInfo(fmt.Sprintf("Error dropping test DB: %v", err))
 	} else {
-		log.Println(" Dropped test DB:", dbname)
+		logger.LogInfo("Dropped test DB:", zap.String("dbname", dbname))
 	}
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Avinal Kumar <avinal.xlvii@gmail.com>
SPDX-License-Identifier: GPL-2.0-only

Thank you for the pull request. Please fill this template as much as
possible and delete unused parts.
-->

## Changes

<!-- Describe your changes here. Ideally GitHub can get the description
from your descriptive commit message(s). Link issues/PR that are relevant
for your changes.-->

- <!-- describe your changes here -->
- Fixes #168 issue


## Submitter Checklist

- [x] Includes tests (if there is a feature changed/added)
- [x] Includes docs ( if changes are user facing)
- [x] I have tested my changes locally.


Refactor: Replace standard log package with structured Zap logger (Issue #168)

Description: 

This PR completes the migration from the standard library log package to the structured zap logger wrapper (pkg/log) across the codebase, as requested in Issue #168. This ensures consistent JSON-structured logging and better observability throughout the application.


Key Changes:

- pkg/utils/util.go & pkg/auth/auth.go: Replaced all instances of log.Printf, log.Println, and log.Fatal with their logger
   equivalents (LogInfo, LogError, LogFatal).
- Removed ANSI Codes: Removed manual ANSI color codes (e.g., \033[31m) from log messages, as structured logging handles
   severity levels and presentation more effectively.
- cmd/laas/gen_external_ref_schema.go: Updated the generator script to use the uniform logger for fatal errors.
- tests/main_test.go: Updated the test suite setup to utilize the new logger configuration.


Verification:
- Run go generate ./... to verify schema generation.
- Run go build ./... to ensure successful compilation.
- Run go test ./tests/... to verify the test suite (requires local DB setup).



