### PR TITLE
feat(auth): replace expires_in with expires_at for token expiry

### DIFF
--- a/cmd/laas/docs/docs.go
+++ b/cmd/laas/docs/docs.go
@@ -3721,9 +3721,9 @@ const docTemplate = `{
                     "type": "string",
                     "example": "your_access_token_here"
                 },
-                "expires_in": {
-                    "type": "integer",
-                    "example": 3600
+                "expires_at": {
+                    "type": "string",
+                    "example": "2026-02-10T15:11:14Z"
                 },
                 "refresh_token": {
                     "type": "string",

--- a/cmd/laas/docs/swagger.json
+++ b/cmd/laas/docs/swagger.json
@@ -3714,9 +3714,9 @@
                     "type": "string",
                     "example": "your_access_token_here"
                 },
-                "expires_in": {
-                    "type": "integer",
-                    "example": 3600
+                "expires_at": {
+                    "type": "string",
+                    "example": "2026-02-10T15:11:14Z"
                 },
                 "refresh_token": {
                     "type": "string",

--- a/cmd/laas/docs/swagger.yaml
+++ b/cmd/laas/docs/swagger.yaml
@@ -861,9 +861,9 @@ definitions:
       access_token:
         example: your_access_token_here
         type: string
-      expires_in:
-        example: 3600
-        type: integer
+      expires_at:
+        example: "2026-02-10T15:11:14Z"
+        type: string
       refresh_token:
         example: your_refresh_token_here
         type: string

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -1085,12 +1085,14 @@ func generateToken(user models.User) (*models.Tokens, error) {
 		UserEmail:   user.UserEmail,
 		UserLevel:   user.UserLevel,
 	}
+
+	AccessTokenExpiresAt := now.Add(time.Hour * time.Duration(accessTokenLifespan))
 	// Build Access Token
 	accessToken, err := jwt.NewBuilder().
 		Issuer(issuer).
 		IssuedAt(now).
 		NotBefore(now).
-		Expiration(now.Add(time.Hour*time.Duration(accessTokenLifespan))).
+		Expiration(AccessTokenExpiresAt).
 		Claim("user", safeClaim).
 		Build()
 	if err != nil {
@@ -1127,7 +1129,7 @@ func generateToken(user models.User) (*models.Tokens, error) {
 	tokens := &models.Tokens{
 		AccessToken:          string(signedAccessToken),
 		RefreshToken:         string(signedRefreshToken),
-		AccessTokenExpiresIn: int64(accessTokenLifespan * 3600), // in seconds
+		AccessTokenExpiresAt: AccessTokenExpiresAt.Format(time.RFC3339),
 	}
 	logger.LogInfo("generateToken completed successfully", zap.String("userID", user.Id.String()))
 	return tokens, nil

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -382,7 +382,7 @@ type ApiResponse[T any] struct {
 type Tokens struct {
 	AccessToken          string `json:"access_token" example:"your_access_token_here"`
 	RefreshToken         string `json:"refresh_token,omitempty" example:"your_refresh_token_here"`
-	AccessTokenExpiresIn int64  `json:"expires_in" example:"3600"`
+	AccessTokenExpiresAt string `json:"expires_at" example:"2026-02-10T15:11:14Z"`
 }
 
 type RefreshToken struct {


### PR DESCRIPTION
## Description
As discussed in this https://github.com/fossology/LicenseDb-UI/pull/26, I updated the expire_in logic to expire_at, and also created a PR in the frontend https://github.com/fossology/LicenseDb-UI/pull/54

## Changes

- Added backend-generated `expires_at` field for access tokens
- Removed reliance on client-side expiry calculation using `expires_in`
- Ensured token expiry is authoritative and latency-safe


## Submitter Checklist

- [x] Includes tests
- [x ] Includes docs
- [x] I have tested my changes locally.

## References

N/A
