### PR TITLE
fix(swagger): fix swagger for obligation_maps routes

### DIFF
--- a/cmd/laas/docs/docs.go
+++ b/cmd/laas/docs/docs.go
@@ -934,7 +934,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/obligation_maps/obligations/{id}/license": {
+        "/obligation_maps/obligation/{id}/license": {
             "put": {
                 "security": [
                     {

--- a/cmd/laas/docs/swagger.json
+++ b/cmd/laas/docs/swagger.json
@@ -927,7 +927,7 @@
                 }
             }
         },
-        "/obligation_maps/obligations/{id}/license": {
+        "/obligation_maps/obligation/{id}/license": {
             "put": {
                 "security": [
                     {

--- a/cmd/laas/docs/swagger.yaml
+++ b/cmd/laas/docs/swagger.yaml
@@ -1584,7 +1584,7 @@ paths:
       summary: Get maps for an obligation
       tags:
       - Obligations
-  /obligation_maps/obligations/{id}/license:
+  /obligation_maps/obligation/{id}/license:
     patch:
       consumes:
       - application/json

--- a/pkg/api/obligationmap.go
+++ b/pkg/api/obligationmap.go
@@ -169,7 +169,7 @@ func GetObligationMapByLicenseId(c *gin.Context) {
 //	@Failure		404				{object}	models.LicenseError	"No license or obligation found."
 //	@Failure		500				{object}	models.LicenseError	"Failure to insert new maps"
 //	@Security		ApiKeyAuth
-//	@Router			/obligation_maps/obligations/{id}/license [patch]
+//	@Router			/obligation_maps/obligation/{id}/license [patch]
 func PatchObligationMap(c *gin.Context) {
 	var obligation models.Obligation
 	var obMapInput models.LicenseMapInput
@@ -284,7 +284,7 @@ func PatchObligationMap(c *gin.Context) {
 //	@Failure		400	{object}	models.LicenseError	"Invalid json body"
 //	@Failure		404	{object}	models.LicenseError	"No license or obligation found."
 //	@Security		ApiKeyAuth
-//	@Router			/obligation_maps/obligations/{id}/license [put]
+//	@Router			/obligation_maps/obligation/{id}/license [put]
 func UpdateLicenseInObligationMap(c *gin.Context) {
 	var obligation models.Obligation
 	var obMapInput models.LicenseListInput


### PR DESCRIPTION
fix: #200
Fix Swagger `@Router` annotations for `obligation_maps` endpoints to match the actual API routes defined in `api.go`.

This removes path mismatches in Swagger UI and prevents confusion when testing PATCH and PUT obligation map endpoints.
