### PR TITLE
fix(models): rename TokenResonse to TokenResponse

### DIFF
--- a/cmd/laas/docs/docs.go
+++ b/cmd/laas/docs/docs.go
@@ -832,7 +832,7 @@ const docTemplate = `{
                     "200": {
                         "description": "JWT token",
                         "schema": {
-                            "$ref": "#/definitions/models.TokenResonse"
+                            "$ref": "#/definitions/models.TokenResponse"
                         }
                     },
                     "401": {
@@ -1837,9 +1837,9 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": " JWT token",
+                        "description": "JWT token",
                         "schema": {
-                            "$ref": "#/definitions/models.TokenResonse"
+                            "$ref": "#/definitions/models.TokenResponse"
                         }
                     },
                     "401": {
@@ -3306,7 +3306,7 @@ const docTemplate = `{
                 }
             }
         },
-        "models.TokenResonse": {
+        "models.TokenResponse": {
             "type": "object",
             "properties": {
                 "data": {

--- a/cmd/laas/docs/swagger.json
+++ b/cmd/laas/docs/swagger.json
@@ -825,7 +825,7 @@
                     "200": {
                         "description": "JWT token",
                         "schema": {
-                            "$ref": "#/definitions/models.TokenResonse"
+                            "$ref": "#/definitions/models.TokenResponse"
                         }
                     },
                     "401": {
@@ -1830,9 +1830,9 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": " JWT token",
+                        "description": "JWT token",
                         "schema": {
-                            "$ref": "#/definitions/models.TokenResonse"
+                            "$ref": "#/definitions/models.TokenResponse"
                         }
                     },
                     "401": {
@@ -3299,7 +3299,7 @@
                 }
             }
         },
-        "models.TokenResonse": {
+        "models.TokenResponse": {
             "type": "object",
             "properties": {
                 "data": {

--- a/cmd/laas/docs/swagger.yaml
+++ b/cmd/laas/docs/swagger.yaml
@@ -722,7 +722,7 @@ definitions:
     required:
     - text
     type: object
-  models.TokenResonse:
+  models.TokenResponse:
     properties:
       data:
         $ref: '#/definitions/models.Tokens'
@@ -1369,7 +1369,7 @@ paths:
         "200":
           description: JWT token
           schema:
-            $ref: '#/definitions/models.TokenResonse'
+            $ref: '#/definitions/models.TokenResponse'
         "401":
           description: Incorrect username or password
           schema:
@@ -2017,9 +2017,9 @@ paths:
       - application/json
       responses:
         "200":
-          description: ' JWT token'
+          description: JWT token
           schema:
-            $ref: '#/definitions/models.TokenResonse'
+            $ref: '#/definitions/models.TokenResponse'
         "401":
           description: Invalid or expired refresh token
           schema:

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -797,9 +797,9 @@ func GetUser(c *gin.Context) {
 //	@Tags			Users
 //	@Accept			json
 //	@Produce		json
-//	@Param			user	body		models.UserLogin	true	"Login credentials"
-//	@Success		200		{object}	models.TokenResonse	"JWT token"
-//	@Failure		401		{object}	models.LicenseError	"Incorrect username or password"
+//	@Param			user	body		models.UserLogin		true	"Login credentials"
+//	@Success		200		{object}	models.TokenResponse	"JWT token"
+//	@Failure		401		{object}	models.LicenseError		"Incorrect username or password"
 //	@Router			/login [post]
 func Login(c *gin.Context) {
 	var input models.UserLogin
@@ -887,7 +887,7 @@ func Login(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, er)
 		return
 	}
-	res := models.TokenResonse{
+	res := models.TokenResponse{
 		Status: http.StatusOK,
 		Data:   *token,
 	}
@@ -944,9 +944,9 @@ func GetUserProfile(c *gin.Context) {
 //	@Tags			Users
 //	@Accept			json
 //	@Produce		json
-//	@Param			user	body		models.RefreshToken	true	"Refresh token payload"
-//	@Success		200		{object}	models.TokenResonse	" JWT token"
-//	@Failure		401		{object}	models.LicenseError	"Invalid or expired refresh token"
+//	@Param			user	body		models.RefreshToken		true	"Refresh token payload"
+//	@Success		200		{object}	models.TokenResponse	"JWT token"
+//	@Failure		401		{object}	models.LicenseError		"Invalid or expired refresh token"
 //	@Router			/refresh-token [post]
 func VerifyRefreshToken(c *gin.Context) {
 	logger.LogInfo("VerifyRefreshToken called")
@@ -1031,7 +1031,7 @@ func VerifyRefreshToken(c *gin.Context) {
 
 	logger.LogInfo("VerifyRefreshToken completed successfully", zap.String("userID", userID.String()))
 
-	c.JSON(http.StatusOK, models.TokenResonse{
+	c.JSON(http.StatusOK, models.TokenResponse{
 		Status: http.StatusOK,
 		Data:   *tokens,
 	})

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -358,7 +358,7 @@ type RefreshToken struct {
 	RefreshToken string `json:"refresh_token" example:"your_refresh_token_here"`
 }
 
-// TokenResonse represents the response structure for token generation API.
-type TokenResonse ApiResponse[Tokens]
+// TokenResponse represents the response structure for token generation API.
+type TokenResponse ApiResponse[Tokens]
 
 // can add all other response structures in similar manner

--- a/tests/auth_test.go
+++ b/tests/auth_test.go
@@ -228,7 +228,7 @@ func TestLoginAndRefreshTokenExpiry(t *testing.T) {
 		w := makeRequest("POST", "/login", loginPayload, false)
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var res models.TokenResonse
+		var res models.TokenResponse
 		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
 			t.Fatalf("failed to unmarshal login response: %v", err)
 		}
@@ -291,7 +291,7 @@ func TestLoginAndRefreshTokenExpiry(t *testing.T) {
 		w := makeRequest("POST", "/refresh-token", refreshPayload, false)
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var res models.TokenResonse
+		var res models.TokenResponse
 		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
 			t.Fatalf("failed to unmarshal refresh response: %v", err)
 		}

--- a/tests/users_comprehensive_test.go
+++ b/tests/users_comprehensive_test.go
@@ -200,7 +200,7 @@ func TestUpdateProfile(t *testing.T) {
 		}
 		loginW := makeRequest("POST", "/login", loginData, false)
 		if loginW.Code == http.StatusOK {
-			var loginRes models.TokenResonse
+			var loginRes models.TokenResponse
 			if err := json.Unmarshal(loginW.Body.Bytes(), &loginRes); err == nil {
 				AuthToken = loginRes.Data.AccessToken
 				resetPassword := models.ProfileUpdate{
@@ -212,7 +212,7 @@ func TestUpdateProfile(t *testing.T) {
 				loginData.Userpassword = "fossy"
 				loginW2 := makeRequest("POST", "/login", loginData, false)
 				if loginW2.Code == http.StatusOK {
-					var loginRes2 models.TokenResonse
+					var loginRes2 models.TokenResponse
 					if err := json.Unmarshal(loginW2.Body.Bytes(), &loginRes2); err == nil {
 						AuthToken = loginRes2.Data.AccessToken
 					}
@@ -290,7 +290,7 @@ func TestVerifyRefreshToken(t *testing.T) {
 		t.Skipf("Cannot login to get refresh token: status %d", loginW.Code)
 	}
 
-	var loginRes models.TokenResonse
+	var loginRes models.TokenResponse
 	if err := json.Unmarshal(loginW.Body.Bytes(), &loginRes); err != nil {
 		t.Fatalf("Failed to parse login response: %v", err)
 	}
@@ -307,7 +307,7 @@ func TestVerifyRefreshToken(t *testing.T) {
 		w := makeRequest("POST", "/refresh-token", refreshReq, false)
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var res models.TokenResonse
+		var res models.TokenResponse
 		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
 			t.Errorf("Error unmarshalling JSON: %v", err)
 			return


### PR DESCRIPTION
## Changes

- Fixes a typo in the exported type name `TokenResonse` — the letter `p` was missing, the correct name is `TokenResponse`
- Updated all usages in [pkg/auth/auth.go](cci:7://file:///home/aaryan/Desktop/LicenseDb/pkg/auth/auth.go:0:0-0:0) (2 struct literals and 2 Swagger `@Success` annotations)
- Updated variable declarations in [tests/auth_test.go](cci:7://file:///home/aaryan/Desktop/LicenseDb/tests/auth_test.go:0:0-0:0) and [tests/users_comprehensive_test.go](cci:7://file:///home/aaryan/Desktop/LicenseDb/tests/users_comprehensive_test.go:0:0-0:0)
- Also fixed a leading space in the Swagger description `" JWT token"` → `"JWT token"` on the `/refresh-token` endpoint



## Submitter Checklist

- [ ] Includes tests (if there is a feature changed/added)
- [x] Includes docs (swagger docs regenerated with corrected type name)
- [x] I have tested my changes locally.
