### PR TITLE
fix(utils): remove tx.Debug() from PerformLicenseMapActions

### DIFF
--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -349,7 +349,7 @@ func PerformLicenseMapActions(tx *gorm.DB, userId uuid.UUID, license *models.Lic
 		}
 	}
 
-	if err := tx.Debug().Model(license).Association("Obligations").Replace(newObligationAssociations); err != nil {
+	if err := tx.Model(license).Association("Obligations").Replace(newObligationAssociations); err != nil {
 		errs = append(errs, err)
 	}
 


### PR DESCRIPTION
## Changes

- Removes hardcoded `tx.Debug()` call from [PerformLicenseMapActions](cci:1://file:///home/aaryan/Desktop/LicenseDb/pkg/utils/util.go:336:0-356:1) in [pkg/utils/util.go](cci:7://file:///home/aaryan/Desktop/LicenseDb/pkg/utils/util.go:0:0-0:0).
- `.Debug()` forced GORM to print every SQL query and its arguments (including UUIDs) to stdout regardless of the configured log level, causing sensitive data exposure and unnecessary performance overhead in production.

## Submitter Checklist

- [ ] Includes tests (if there is a feature changed/added)
- [ ] Includes docs ( if changes are user facing)
- [x] I have tested my changes locally.
