### PR TITLE
Fix status codes in UpdateProfile, CreateObligation, and DeleteObligation

### DIFF
--- a/pkg/api/obligations.go
+++ b/pkg/api/obligations.go
@@ -253,7 +253,7 @@ func CreateObligation(c *gin.Context) {
 		obdto := ob.ConvertToObligationResponseDTO()
 		res := models.ObligationResponse{
 			Data:   []models.ObligationResponseDTO{obdto},
-			Status: http.StatusOK,
+			Status: http.StatusCreated,
 			Meta: models.PaginationMeta{
 				ResourceCount: 1,
 			},
@@ -441,7 +441,7 @@ func DeleteObligation(c *gin.Context) {
 			Path:      c.Request.URL.Path,
 			Timestamp: time.Now().Format(time.RFC3339),
 		}
-		c.JSON(http.StatusNotFound, er)
+		c.JSON(http.StatusInternalServerError, er)
 		return
 	}
 	c.Status(http.StatusNoContent)

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -612,7 +612,7 @@ func UpdateProfile(c *gin.Context) {
 
 		res := models.UserResponse{
 			Data:   []models.User{updatedUser},
-			Status: http.StatusCreated,
+			Status: http.StatusOK,
 			Meta: &models.PaginationMeta{
 				ResourceCount: 1,
 			},


### PR DESCRIPTION
## Changes

- Fix [UpdateProfile](cci:1://file:///home/aaryan/Desktop/LicenseDb/pkg/auth/auth.go:513:0-624:1) response body returning `Status: 201` (`http.StatusCreated`) while the HTTP response was correctly `200 OK` — body now consistently uses `http.StatusOK`
- Fix [CreateObligation](cci:1://file:///home/aaryan/Desktop/LicenseDb/pkg/api/obligations.go:164:0-265:1) response body returning `Status: 200` (`http.StatusOK`) while the HTTP response was correctly `201 Created` — body now consistently uses `http.StatusCreated`
- Fix [DeleteObligation](cci:1://file:///home/aaryan/Desktop/LicenseDb/pkg/api/obligations.go:394:0-447:1) sending `c.JSON(http.StatusNotFound, er)` on a DB update failure — the record was already successfully fetched at that point, so the correct status is `http.StatusInternalServerError`

## Submitter Checklist

- [ ] Includes tests (if there is a feature changed/added)
- [ ] Includes docs ( if changes are user facing)
- [x] I have tested my changes locally.

## References

| Location | Was | Now |
|---|---|---|
| [pkg/auth/auth.go](cci:7://file:///home/aaryan/Desktop/LicenseDb/pkg/auth/auth.go:0:0-0:0) — [UpdateProfile](cci:1://file:///home/aaryan/Desktop/LicenseDb/pkg/auth/auth.go:513:0-624:1) response body | `Status: http.StatusCreated` (201) | `Status: http.StatusOK` (200) |
| [pkg/api/obligations.go](cci:7://file:///home/aaryan/Desktop/LicenseDb/pkg/api/obligations.go:0:0-0:0) — [CreateObligation](cci:1://file:///home/aaryan/Desktop/LicenseDb/pkg/api/obligations.go:164:0-265:1) response body | `Status: http.StatusOK` (200) | `Status: http.StatusCreated` (201) |
| [pkg/api/obligations.go](cci:7://file:///home/aaryan/Desktop/LicenseDb/pkg/api/obligations.go:0:0-0:0) — [DeleteObligation](cci:1://file:///home/aaryan/Desktop/LicenseDb/pkg/api/obligations.go:394:0-447:1) update failure | `c.JSON(http.StatusNotFound, er)` (404) | `c.JSON(http.StatusInternalServerError, er)` (500) |
