### PR TITLE
fix(messages): fix typos and misleading error messages in audit, dash…

### DIFF
--- a/pkg/api/audit.go
+++ b/pkg/api/audit.go
@@ -96,7 +96,7 @@ func GetAudit(c *gin.Context) {
 	if err != nil {
 		er := models.LicenseError{
 			Status:    http.StatusBadRequest,
-			Message:   fmt.Sprintf("no license with id '%s' exists", id),
+			Message:   fmt.Sprintf("no audit with id '%s' exists", id),
 			Error:     err.Error(),
 			Path:      c.Request.URL.Path,
 			Timestamp: time.Now().Format(time.RFC3339),
@@ -154,7 +154,7 @@ func GetChangeLogs(c *gin.Context) {
 	if err != nil {
 		er := models.LicenseError{
 			Status:    http.StatusBadRequest,
-			Message:   fmt.Sprintf("no license with id '%s' exists", id),
+			Message:   fmt.Sprintf("no audit with id '%s' exists", id),
 			Error:     err.Error(),
 			Path:      c.Request.URL.Path,
 			Timestamp: time.Now().Format(time.RFC3339),
@@ -221,7 +221,7 @@ func GetChangeLogbyId(c *gin.Context) {
 	if err != nil {
 		er := models.LicenseError{
 			Status:    http.StatusBadRequest,
-			Message:   fmt.Sprintf("no license with id '%s' exists", auditId),
+			Message:   fmt.Sprintf("no audit with id '%s' exists", auditId),
 			Error:     err.Error(),
 			Path:      c.Request.URL.Path,
 			Timestamp: time.Now().Format(time.RFC3339),
@@ -234,7 +234,7 @@ func GetChangeLogbyId(c *gin.Context) {
 	if err != nil {
 		er := models.LicenseError{
 			Status:    http.StatusBadRequest,
-			Message:   fmt.Sprintf("no license with id '%s' exists", changelogId),
+			Message:   fmt.Sprintf("no changelog with id '%s' exists", changelogId),
 			Error:     err.Error(),
 			Path:      c.Request.URL.Path,
 			Timestamp: time.Now().Format(time.RFC3339),

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -98,7 +98,7 @@ func GetDashboardData(c *gin.Context) {
 		er := models.LicenseError{
 			Status:    http.StatusInternalServerError,
 			Message:   "something went wrong",
-			Error:     "error fetching risk liicense frequencies",
+			Error:     "error fetching risk license frequencies",
 			Path:      c.Request.URL.Path,
 			Timestamp: time.Now().Format(time.RFC3339),
 		}

--- a/pkg/api/obligations.go
+++ b/pkg/api/obligations.go
@@ -372,7 +372,7 @@ func UpdateObligation(c *gin.Context) {
 	}); err != nil {
 		er := models.LicenseError{
 			Status:    http.StatusBadRequest,
-			Message:   "Failed to update license",
+			Message:   "Failed to update obligation",
 			Error:     err.Error(),
 			Path:      c.Request.URL.Path,
 			Timestamp: time.Now().Format(time.RFC3339),
@@ -636,7 +636,7 @@ func ImportObligations(c *gin.Context) {
 				if err := addChangelogsForObligation(tx, userId, &oldObligation, &models.Obligation{}); err != nil {
 					res.Data = append(res.Data, models.LicenseError{
 						Status:    http.StatusInternalServerError,
-						Message:   "Failed to update license",
+						Message:   "Failed to update obligation",
 						Error:     err.Error(),
 						Path:      c.Request.URL.Path,
 						Timestamp: time.Now().Format(time.RFC3339),
@@ -684,7 +684,7 @@ func ImportObligations(c *gin.Context) {
 						if err := tx.Joins("Classification").Joins("Type").Preload("Licenses").First(&oldObligation, oldObligation.Id).Error; err != nil {
 							res.Data = append(res.Data, models.LicenseError{
 								Status:    http.StatusInternalServerError,
-								Message:   "Failed to update license",
+								Message:   "Failed to update obligation",
 								Error:     err.Error(),
 								Path:      c.Request.URL.Path,
 								Timestamp: time.Now().Format(time.RFC3339),
@@ -695,7 +695,7 @@ func ImportObligations(c *gin.Context) {
 						if err := addChangelogsForObligation(tx, userId, &oldObligation, &models.Obligation{}); err != nil {
 							res.Data = append(res.Data, models.LicenseError{
 								Status:    http.StatusInternalServerError,
-								Message:   "Failed to update license",
+								Message:   "Failed to update obligation",
 								Error:     err.Error(),
 								Path:      c.Request.URL.Path,
 								Timestamp: time.Now().Format(time.RFC3339),
@@ -734,7 +734,7 @@ func ImportObligations(c *gin.Context) {
 					if err := tx.Model(&models.Obligation{}).Where(models.Obligation{Id: oldObligation.Id}).UpdateColumn("external_ref", gorm.Expr("jsonb_strip_nulls(COALESCE(external_ref, '{}'::jsonb) || ?)", ob.ExternalRef)).Error; err != nil {
 						res.Data = append(res.Data, models.LicenseError{
 							Status:    http.StatusInternalServerError,
-							Message:   "Failed to update license",
+							Message:   "Failed to update obligation",
 							Error:     err.Error(),
 							Path:      c.Request.URL.Path,
 							Timestamp: time.Now().Format(time.RFC3339),
@@ -745,7 +745,7 @@ func ImportObligations(c *gin.Context) {
 					if err := tx.Omit("ExternalRef", "Licenses", "Topic").Updates(&newObligation).Error; err != nil {
 						res.Data = append(res.Data, models.LicenseError{
 							Status:    http.StatusInternalServerError,
-							Message:   "Failed to update license",
+							Message:   "Failed to update obligation",
 							Error:     err.Error(),
 							Path:      c.Request.URL.Path,
 							Timestamp: time.Now().Format(time.RFC3339),
@@ -771,7 +771,7 @@ func ImportObligations(c *gin.Context) {
 					if err := tx.Joins("Type").Joins("Classification").Preload("Licenses").First(&newObligation).Error; err != nil {
 						res.Data = append(res.Data, models.LicenseError{
 							Status:    http.StatusInternalServerError,
-							Message:   "Failed to update license",
+							Message:   "Failed to update obligation",
 							Error:     err.Error(),
 							Path:      c.Request.URL.Path,
 							Timestamp: time.Now().Format(time.RFC3339),
@@ -782,7 +782,7 @@ func ImportObligations(c *gin.Context) {
 					if err := addChangelogsForObligation(tx, userId, &newObligation, &oldObligation); err != nil {
 						res.Data = append(res.Data, models.LicenseError{
 							Status:    http.StatusInternalServerError,
-							Message:   "Failed to update license",
+							Message:   "Failed to update obligation",
 							Error:     err.Error(),
 							Path:      c.Request.URL.Path,
 							Timestamp: time.Now().Format(time.RFC3339),


### PR DESCRIPTION
## Changes

- Fix typo in [dashboard.go](cci:7://file:///home/aaryan/Desktop/LicenseDb/pkg/api/dashboard.go:0:0-0:0): `"error fetching risk liicense frequencies"` → `"error fetching risk license frequencies"` (double `i`)
- Fix misleading error messages in [audit.go](cci:7://file:///home/aaryan/Desktop/LicenseDb/pkg/api/audit.go:0:0-0:0) — UUID parse errors in [GetAudit](cci:1://file:///home/aaryan/Desktop/LicenseDb/pkg/api/audit.go:77:0-132:1), [GetChangeLogs](cci:1://file:///home/aaryan/Desktop/LicenseDb/pkg/api/audit.go:134:0-199:1), and [GetChangeLogbyId](cci:1://file:///home/aaryan/Desktop/LicenseDb/pkg/api/audit.go:201:0-275:1) were copy-pasted from the license handlers and incorrectly said `"no license with id '%s' exists"`; now correctly say `"no audit with id '%s' exists"` or `"no changelog with id '%s' exists"`
- Fix misleading error messages in [obligations.go](cci:7://file:///home/aaryan/Desktop/LicenseDb/pkg/api/obligations.go:0:0-0:0) — 8 occurrences of `"Failed to update license"` in obligation update/import paths were copy-pasted from the license handler; now correctly say `"Failed to update obligation"`


## Submitter Checklist

- [ ] Includes tests (if there is a feature changed/added)
- [ ] Includes docs ( if changes are user facing)
- [x] I have tested my changes locally.

## References

| Location | Was | Now |
|---|---|---|
| `pkg/api/dashboard.go:101` | `"error fetching risk liicense frequencies"` | `"error fetching risk license frequencies"` |
| `pkg/api/audit.go:99` — [GetAudit](cci:1://file:///home/aaryan/Desktop/LicenseDb/pkg/api/audit.go:77:0-132:1) | `"no license with id '%s' exists"` | `"no audit with id '%s' exists"` |
| `pkg/api/audit.go:157` — [GetChangeLogs](cci:1://file:///home/aaryan/Desktop/LicenseDb/pkg/api/audit.go:134:0-199:1) | `"no license with id '%s' exists"` | `"no audit with id '%s' exists"` |
| `pkg/api/audit.go:224` — [GetChangeLogbyId](cci:1://file:///home/aaryan/Desktop/LicenseDb/pkg/api/audit.go:201:0-275:1) (audit ID) | `"no license with id '%s' exists"` | `"no audit with id '%s' exists"` |
| `pkg/api/audit.go:237` — [GetChangeLogbyId](cci:1://file:///home/aaryan/Desktop/LicenseDb/pkg/api/audit.go:201:0-275:1) (changelog ID) | `"no license with id '%s' exists"` | `"no changelog with id '%s' exists"` |
| [pkg/api/obligations.go](cci:7://file:///home/aaryan/Desktop/LicenseDb/pkg/api/obligations.go:0:0-0:0) (8 occurrences) | `"Failed to update license"` | `"Failed to update obligation"` |
