### PR TITLE
feat(category): Make obligation category configurable

### DIFF
--- a/cmd/laas/docs/docs.go
+++ b/cmd/laas/docs/docs.go
@@ -968,6 +968,166 @@ const docTemplate = `{
                 }
             }
         },
+        "/obligations/categories": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": [],
+                        "{}": []
+                    }
+                ],
+                "description": "Get all active obligation categories from the service",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Obligations"
+                ],
+                "summary": "Get all active obligation categories",
+                "operationId": "GetAllObligationCategories",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Active obligation categories only",
+                        "name": "active",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.ObligationCategoryResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Unable to fetch obligation categories",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Unable to fetch obligation categories",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Create an obligation category",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Obligations"
+                ],
+                "summary": "Create an obligation category",
+                "operationId": "CreateObligationCategory",
+                "parameters": [
+                    {
+                        "description": "Obligation category to create",
+                        "name": "obligation_category",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.ObligationCategory"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.ObligationCategoryResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid json body",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "409": {
+                        "description": "obligation category already exists",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "500": {
+                        "description": "something went wrong while creating new obligation category",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    }
+                }
+            }
+        },
+        "/obligations/categories/{category}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Deactivate an obligation category",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Obligations"
+                ],
+                "summary": "Deactivate obligation category",
+                "operationId": "DeleteObligationCategory",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Obligation Category",
+                        "name": "category",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "cannot delete obligation category 'DISTRIBUTION' as it's still referenced by some obligations",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "404": {
+                        "description": "obligation category 'DISTRIBUTION' not found",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "500": {
+                        "description": "something went wrong while deleting obligation category",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    }
+                }
+            }
+        },
         "/obligations/classifications": {
             "get": {
                 "security": [
@@ -2798,6 +2958,36 @@ const docTemplate = `{
                 "url": {
                     "type": "string",
                     "example": "https://opensource.org/licenses/MIT"
+                }
+            }
+        },
+        "models.ObligationCategory": {
+            "type": "object",
+            "required": [
+                "category"
+            ],
+            "properties": {
+                "category": {
+                    "type": "string",
+                    "example": "GENERAL"
+                }
+            }
+        },
+        "models.ObligationCategoryResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.ObligationCategory"
+                    }
+                },
+                "paginationmeta": {
+                    "$ref": "#/definitions/models.PaginationMeta"
+                },
+                "status": {
+                    "type": "integer",
+                    "example": 200
                 }
             }
         },

--- a/cmd/laas/docs/swagger.json
+++ b/cmd/laas/docs/swagger.json
@@ -961,6 +961,166 @@
                 }
             }
         },
+        "/obligations/categories": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": [],
+                        "{}": []
+                    }
+                ],
+                "description": "Get all active obligation categories from the service",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Obligations"
+                ],
+                "summary": "Get all active obligation categories",
+                "operationId": "GetAllObligationCategories",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Active obligation categories only",
+                        "name": "active",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.ObligationCategoryResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Unable to fetch obligation categories",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Unable to fetch obligation categories",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Create an obligation category",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Obligations"
+                ],
+                "summary": "Create an obligation category",
+                "operationId": "CreateObligationCategory",
+                "parameters": [
+                    {
+                        "description": "Obligation category to create",
+                        "name": "obligation_category",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.ObligationCategory"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.ObligationCategoryResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "invalid json body",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "409": {
+                        "description": "obligation category already exists",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "500": {
+                        "description": "something went wrong while creating new obligation category",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    }
+                }
+            }
+        },
+        "/obligations/categories/{category}": {
+            "delete": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Deactivate an obligation category",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Obligations"
+                ],
+                "summary": "Deactivate obligation category",
+                "operationId": "DeleteObligationCategory",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Obligation Category",
+                        "name": "category",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "cannot delete obligation category 'DISTRIBUTION' as it's still referenced by some obligations",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "404": {
+                        "description": "obligation category 'DISTRIBUTION' not found",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    },
+                    "500": {
+                        "description": "something went wrong while deleting obligation category",
+                        "schema": {
+                            "$ref": "#/definitions/models.LicenseError"
+                        }
+                    }
+                }
+            }
+        },
         "/obligations/classifications": {
             "get": {
                 "security": [
@@ -2791,6 +2951,36 @@
                 "url": {
                     "type": "string",
                     "example": "https://opensource.org/licenses/MIT"
+                }
+            }
+        },
+        "models.ObligationCategory": {
+            "type": "object",
+            "required": [
+                "category"
+            ],
+            "properties": {
+                "category": {
+                    "type": "string",
+                    "example": "GENERAL"
+                }
+            }
+        },
+        "models.ObligationCategoryResponse": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.ObligationCategory"
+                    }
+                },
+                "paginationmeta": {
+                    "$ref": "#/definitions/models.PaginationMeta"
+                },
+                "status": {
+                    "type": "integer",
+                    "example": 200
                 }
             }
         },

--- a/cmd/laas/docs/swagger.yaml
+++ b/cmd/laas/docs/swagger.yaml
@@ -369,6 +369,26 @@ definitions:
         example: https://opensource.org/licenses/MIT
         type: string
     type: object
+  models.ObligationCategory:
+    properties:
+      category:
+        example: GENERAL
+        type: string
+    required:
+    - category
+    type: object
+  models.ObligationCategoryResponse:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/models.ObligationCategory'
+        type: array
+      paginationmeta:
+        $ref: '#/definitions/models.PaginationMeta'
+      status:
+        example: 200
+        type: integer
+    type: object
   models.ObligationClassification:
     properties:
       classification:
@@ -1592,6 +1612,110 @@ paths:
       - '{}': []
         ApiKeyAuth: []
       summary: Fetches audits corresponding to an obligation
+      tags:
+      - Obligations
+  /obligations/categories:
+    get:
+      consumes:
+      - application/json
+      description: Get all active obligation categories from the service
+      operationId: GetAllObligationCategories
+      parameters:
+      - description: Active obligation categories only
+        in: query
+        name: active
+        required: true
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.ObligationCategoryResponse'
+        "400":
+          description: Unable to fetch obligation categories
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+        "500":
+          description: Unable to fetch obligation categories
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+      security:
+      - '{}': []
+        ApiKeyAuth: []
+      summary: Get all active obligation categories
+      tags:
+      - Obligations
+    post:
+      consumes:
+      - application/json
+      description: Create an obligation category
+      operationId: CreateObligationCategory
+      parameters:
+      - description: Obligation category to create
+        in: body
+        name: obligation_category
+        required: true
+        schema:
+          $ref: '#/definitions/models.ObligationCategory'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/models.ObligationCategoryResponse'
+        "400":
+          description: invalid json body
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+        "409":
+          description: obligation category already exists
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+        "500":
+          description: something went wrong while creating new obligation category
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+      security:
+      - ApiKeyAuth: []
+      summary: Create an obligation category
+      tags:
+      - Obligations
+  /obligations/categories/{category}:
+    delete:
+      consumes:
+      - application/json
+      description: Deactivate an obligation category
+      operationId: DeleteObligationCategory
+      parameters:
+      - description: Obligation Category
+        in: path
+        name: category
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: cannot delete obligation category 'DISTRIBUTION' as it's still
+            referenced by some obligations
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+        "404":
+          description: obligation category 'DISTRIBUTION' not found
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+        "500":
+          description: something went wrong while deleting obligation category
+          schema:
+            $ref: '#/definitions/models.LicenseError'
+      security:
+      - ApiKeyAuth: []
+      summary: Deactivate obligation category
       tags:
       - Obligations
   /obligations/classifications:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -155,6 +155,9 @@ func Router() *gin.Engine {
 				obligations.POST("/classifications", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), CreateObligationClassification)
 				obligations.DELETE("/classifications/:classification", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), DeleteObligationClassification)
 				obligations.POST("/similarity", getSimilarObligations)
+				obligations.GET("/categories", GetAllObligationCategories)
+				obligations.POST("/categories", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), CreateObligationCategory)
+				obligations.DELETE("/categories/:category", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), DeleteObligationCategory)
 			}
 			audit := authorizedv1.Group("/audits")
 			{
@@ -197,6 +200,7 @@ func Router() *gin.Engine {
 				obligations.GET("export", ExportObligations)
 				obligations.GET("/types", GetAllObligationType)
 				obligations.GET("/classifications", GetAllObligationClassification)
+				obligations.GET("/categories", GetAllObligationCategories)
 			}
 			audit := unAuthorizedv1.Group("/audits")
 			{
@@ -262,6 +266,8 @@ func Router() *gin.Engine {
 				obligations.DELETE("/types/:type", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), DeleteObligationType)
 				obligations.POST("/classifications", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), CreateObligationClassification)
 				obligations.DELETE("/classifications/:classification", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), DeleteObligationClassification)
+				obligations.POST("/categories", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), CreateObligationCategory)
+				obligations.DELETE("/categories/:category", middleware.RoleBasedAccessMiddleware([]string{"ADMIN"}), DeleteObligationCategory)
 				obligations.POST("/similarity", getSimilarObligations)
 			}
 			oidcClient := authorizedv1.Group("/oidcClients")

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -92,6 +92,7 @@ func GetDashboardData(c *gin.Context) {
 
 	if err := db.DB.Model(&models.LicenseDB{}).
 		Select("rf_risk as risk, count(*) as count").
+		Where(&models.LicenseDB{Active: &active}).
 		Group("rf_risk").
 		Scan(&licenseFrequency).Error; err != nil {
 		logger.LogError("error fetching risk license frequencies", zap.Error(err))
@@ -107,8 +108,10 @@ func GetDashboardData(c *gin.Context) {
 	}
 
 	if err := db.DB.Model(&models.Obligation{}).
-		Select("category, count(*) as count").
-		Group("category").
+		Select("obligation_categories.category, count(*) as count").
+		Joins("JOIN obligation_categories ON obligation_categories.id = obligations.obligation_category_id").
+		Where(&models.Obligation{Active: &active}).
+		Group("obligation_categories.category").
 		Scan(&categoryFrequency).Error; err != nil {
 		logger.LogError("error fetching category obligation frequencies", zap.Error(err))
 		er := models.LicenseError{

--- a/pkg/api/obligationCategories.go
+++ b/pkg/api/obligationCategories.go
@@ -1,0 +1,243 @@
+// SPDX-FileCopyrightText: 2026 Siemens AG
+// SPDX-FileContributor: Dearsh Oberoi <dearsh.oberoi@siemens.com>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/fossology/LicenseDb/pkg/db"
+	"github.com/fossology/LicenseDb/pkg/models"
+	"github.com/fossology/LicenseDb/pkg/utils"
+	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// GetAllObligationCategories retrieves a list of all obligation categories
+//
+//	@Summary		Get all active obligation categories
+//	@Description	Get all active obligation categories from the service
+//	@Id				GetAllObligationCategories
+//	@Tags			Obligations
+//	@Accept			json
+//	@Produce		json
+//	@Param			active	query		bool	true	"Active obligation categories only"
+//	@Success		200		{object}	models.ObligationCategoryResponse
+//	@Failure		400		{object}	models.LicenseError	"Unable to fetch obligation categories"
+//	@Failure		500		{object}	models.LicenseError	"Unable to fetch obligation categories"
+//	@Security		ApiKeyAuth || {}
+//	@Router			/obligations/categories [get]
+func GetAllObligationCategories(c *gin.Context) {
+	var obligationCategories []models.ObligationCategory
+	active := c.Query("active")
+	if active == "" {
+		active = "true"
+	}
+	var parsedActive bool
+	parsedActive, err := strconv.ParseBool(active)
+	if err != nil {
+		er := models.LicenseError{
+			Status:    http.StatusBadRequest,
+			Message:   "Invalid active value",
+			Error:     fmt.Sprintf("Parsing failed for value '%s'", active),
+			Path:      c.Request.URL.Path,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		c.JSON(http.StatusBadRequest, er)
+		return
+	}
+
+	query := db.DB.Model(&models.ObligationCategory{}).
+		Where("active = ?", parsedActive)
+	if err = query.Find(&obligationCategories).Error; err != nil {
+		er := models.LicenseError{
+			Status:    http.StatusInternalServerError,
+			Message:   "Unable to fetch obligation categories",
+			Error:     err.Error(),
+			Path:      c.Request.URL.Path,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		c.JSON(http.StatusInternalServerError, er)
+		return
+	}
+
+	res := models.ObligationCategoryResponse{
+		Data:   obligationCategories,
+		Status: http.StatusOK,
+		Meta: &models.PaginationMeta{
+			ResourceCount: len(obligationCategories),
+		},
+	}
+
+	c.JSON(http.StatusOK, res)
+}
+
+// CreateObligationCategory creates a new obligation category.
+//
+//	@Summary		Create an obligation category
+//	@Description	Create an obligation category
+//	@Id				CreateObligationCategory
+//	@Tags			Obligations
+//	@Accept			json
+//	@Produce		json
+//	@Param			obligation_category	body		models.ObligationCategory	true	"Obligation category to create"
+//	@Success		201					{object}	models.ObligationCategoryResponse
+//	@Failure		400					{object}	models.LicenseError	"invalid json body"
+//	@Failure		409					{object}	models.LicenseError	"obligation category already exists"
+//	@Failure		500					{object}	models.LicenseError	"something went wrong while creating new obligation category"
+//	@Security		ApiKeyAuth
+//	@Router			/obligations/categories [post]
+func CreateObligationCategory(c *gin.Context) {
+	var obCategory models.ObligationCategory
+	userId := c.MustGet("userId").(uuid.UUID)
+	if err := c.ShouldBindJSON(&obCategory); err != nil {
+		er := models.LicenseError{
+			Status:    http.StatusBadRequest,
+			Message:   "invalid json body",
+			Error:     err.Error(),
+			Path:      c.Request.URL.Path,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		c.JSON(http.StatusBadRequest, er)
+		return
+	}
+
+	err, status := utils.CreateObCategory(&obCategory, userId)
+
+	switch status {
+	case utils.CREATED:
+		res := models.ObligationCategoryResponse{
+			Status: http.StatusCreated,
+			Data:   []models.ObligationCategory{obCategory},
+			Meta: &models.PaginationMeta{
+				ResourceCount: 1,
+			},
+		}
+		c.JSON(http.StatusCreated, res)
+
+	case utils.CONFLICT:
+		er := models.LicenseError{
+			Status:    http.StatusConflict,
+			Message:   "obligation category already exists",
+			Error:     err.Error(),
+			Path:      c.Request.URL.Path,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		c.JSON(http.StatusConflict, er)
+
+	case utils.CONFLICT_ACTIVATION_FAILED:
+		er := models.LicenseError{
+			Status:    http.StatusConflict,
+			Message:   "obligation category already exists, something went wrong while reactvating it",
+			Error:     err.Error(),
+			Path:      c.Request.URL.Path,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		c.JSON(http.StatusConflict, er)
+
+	case utils.VALIDATION_FAILED:
+		er := models.LicenseError{
+			Status:    http.StatusBadRequest,
+			Message:   "can not create obligation category with these field values",
+			Error:     fmt.Sprintf("field '%s' failed validation: %s\n", err.(validator.ValidationErrors)[0].Field(), err.(validator.ValidationErrors)[0].Tag()),
+			Path:      c.Request.URL.Path,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		c.JSON(http.StatusBadRequest, er)
+
+	default:
+		er := models.LicenseError{
+			Status:    http.StatusInternalServerError,
+			Message:   "something went wrong while creating new obligation category",
+			Error:     err.Error(),
+			Path:      c.Request.URL.Path,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		c.JSON(http.StatusInternalServerError, er)
+
+	}
+}
+
+// DeleteObligationCategory marks an existing obligation category record as inactive
+//
+//	@Summary		Deactivate obligation category
+//	@Description	Deactivate an obligation category
+//	@Id				DeleteObligationCategory
+//	@Tags			Obligations
+//	@Accept			json
+//	@Produce		json
+//	@Param			category	path	string	true	"Obligation Category"
+//	@Success		200
+//	@Failure		400	{object}	models.LicenseError	"cannot delete obligation category 'DISTRIBUTION' as it's still referenced by some obligations"
+//	@Failure		404	{object}	models.LicenseError	"obligation category 'DISTRIBUTION' not found"
+//	@Failure		500	{object}	models.LicenseError	"something went wrong while deleting obligation category"
+//	@Security		ApiKeyAuth
+//	@Router			/obligations/categories/{category} [delete]
+func DeleteObligationCategory(c *gin.Context) {
+	var obCategory models.ObligationCategory
+	obCategoryParam := c.Param("category")
+	userId := c.MustGet("userId").(uuid.UUID)
+	if err := db.DB.Where(models.ObligationCategory{Category: obCategoryParam}).First(&obCategory).Error; err != nil {
+		er := models.LicenseError{
+			Status:    http.StatusNotFound,
+			Message:   fmt.Sprintf("obligation category '%s' not found", obCategoryParam),
+			Error:     err.Error(),
+			Path:      c.Request.URL.Path,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		c.JSON(http.StatusNotFound, er)
+		return
+	}
+
+	if !*obCategory.Active {
+		c.Status(http.StatusOK)
+		return
+	}
+
+	var count int64
+	if err := db.DB.Model(&models.Obligation{}).Where(&models.Obligation{ObligationCategoryId: obCategory.Id}).Count(&count).Error; err != nil {
+		er := models.LicenseError{
+			Status:    http.StatusInternalServerError,
+			Message:   "something went wrong while deleting obligation category",
+			Error:     err.Error(),
+			Path:      c.Request.URL.Path,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		c.JSON(http.StatusInternalServerError, er)
+		return
+	}
+
+	if count > 0 {
+		er := models.LicenseError{
+			Status:    http.StatusBadRequest,
+			Message:   fmt.Sprintf("cannot delete obligation category '%s' as it's still referenced by some obligations", obCategory.Category),
+			Error:     fmt.Sprintf("cannot delete obligation category '%s' as it's still referenced by some obligations", obCategory.Category),
+			Path:      c.Request.URL.Path,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		c.JSON(http.StatusBadRequest, er)
+		return
+	}
+
+	if err := db.DB.Transaction(func(tx *gorm.DB) error {
+		return utils.ToggleObligationCategoryActiveStatus(userId, tx, &obCategory)
+	}); err != nil {
+		er := models.LicenseError{
+			Status:    http.StatusInternalServerError,
+			Message:   "something went wrong while deleting obligation category",
+			Error:     err.Error(),
+			Path:      c.Request.URL.Path,
+			Timestamp: time.Now().Format(time.RFC3339),
+		}
+		c.JSON(http.StatusInternalServerError, er)
+		return
+	}
+	c.Status(http.StatusOK)
+}

--- a/pkg/api/obligations.go
+++ b/pkg/api/obligations.go
@@ -78,7 +78,7 @@ func GetAllObligation(c *gin.Context) {
 
 	query.Order(queryOrderString)
 
-	if err = query.Joins("Type").Joins("Classification").Preload("Licenses").Find(&obligations).Error; err != nil {
+	if err = query.Joins("Type").Joins("Classification").Joins("Category").Preload("Licenses").Find(&obligations).Error; err != nil {
 		er := models.LicenseError{
 			Status:    http.StatusInternalServerError,
 			Message:   "Unable to fetch obligations",
@@ -138,7 +138,7 @@ func GetObligation(c *gin.Context) {
 		return
 	}
 
-	if err := query.Joins("Type").Joins("Classification").Preload("Licenses").Where(models.Obligation{Id: obligationId}).First(&obligation).Error; err != nil {
+	if err := query.Joins("Type").Joins("Classification").Joins("Category").Preload("Licenses").Where(models.Obligation{Id: obligationId}).First(&obligation).Error; err != nil {
 		er := models.LicenseError{
 			Status:    http.StatusNotFound,
 			Message:   fmt.Sprintf("obligation with id '%s' not found", obligationId.String()),
@@ -226,7 +226,7 @@ func CreateObligation(c *gin.Context) {
 			return errors.New(combinedMapErrors.String())
 		}
 
-		if err := tx.Joins("Classification").Joins("Type").Preload("Licenses").First(&ob, ob.Id).Error; err != nil {
+		if err := tx.Joins("Classification").Joins("Category").Joins("Type").Preload("Licenses").First(&ob, ob.Id).Error; err != nil {
 			er := models.LicenseError{
 				Status:    http.StatusInternalServerError,
 				Message:   "Failed to create obligation",
@@ -310,7 +310,7 @@ func UpdateObligation(c *gin.Context) {
 		return
 	}
 
-	if err := db.DB.Joins("Classification").Joins("Type").Preload("Licenses").Where(models.Obligation{Id: obligationId}).First(&oldObligation).Error; err != nil {
+	if err := db.DB.Joins("Classification").Joins("Category").Joins("Type").Preload("Licenses").Where(models.Obligation{Id: obligationId}).First(&oldObligation).Error; err != nil {
 		er := models.LicenseError{
 			Status:    http.StatusNotFound,
 			Message:   fmt.Sprintf("obligation with id '%s' not found", obligationId.String()),
@@ -360,7 +360,7 @@ func UpdateObligation(c *gin.Context) {
 			}
 		}
 
-		if err := tx.Joins("Type").Joins("Classification").Preload("Licenses").First(&newObligation).Error; err != nil {
+		if err := tx.Joins("Type").Joins("Classification").Joins("Category").Preload("Licenses").First(&newObligation).Error; err != nil {
 			return err
 		}
 
@@ -621,7 +621,7 @@ func ImportObligations(c *gin.Context) {
 					}
 				}
 
-				if err := tx.Joins("Classification").Joins("Type").Preload("Licenses").First(&oldObligation, oldObligation.Id).Error; err != nil {
+				if err := tx.Joins("Classification").Joins("Category").Joins("Type").Preload("Licenses").First(&oldObligation, oldObligation.Id).Error; err != nil {
 					er := models.LicenseError{
 						Status:    http.StatusInternalServerError,
 						Message:   "Failed to create obligation",
@@ -681,7 +681,7 @@ func ImportObligations(c *gin.Context) {
 							}
 						}
 
-						if err := tx.Joins("Classification").Joins("Type").Preload("Licenses").First(&oldObligation, oldObligation.Id).Error; err != nil {
+						if err := tx.Joins("Classification").Joins("Category").Joins("Type").Preload("Licenses").First(&oldObligation, oldObligation.Id).Error; err != nil {
 							res.Data = append(res.Data, models.LicenseError{
 								Status:    http.StatusInternalServerError,
 								Message:   "Failed to update license",
@@ -768,7 +768,7 @@ func ImportObligations(c *gin.Context) {
 						}
 					}
 
-					if err := tx.Joins("Type").Joins("Classification").Preload("Licenses").First(&newObligation).Error; err != nil {
+					if err := tx.Joins("Type").Joins("Classification").Joins("Category").Preload("Licenses").First(&newObligation).Error; err != nil {
 						res.Data = append(res.Data, models.LicenseError{
 							Status:    http.StatusInternalServerError,
 							Message:   "Failed to update license",
@@ -822,7 +822,7 @@ func ImportObligations(c *gin.Context) {
 func ExportObligations(c *gin.Context) {
 	var obligations []models.Obligation
 
-	if err := db.DB.Joins("Type").Joins("Classification").Preload("Licenses").Find(&obligations).Error; err != nil {
+	if err := db.DB.Joins("Type").Joins("Classification").Joins("Category").Preload("Licenses").Find(&obligations).Error; err != nil {
 		er := models.LicenseError{
 			Status:    http.StatusInternalServerError,
 			Message:   "Failed to fetch obligations",

--- a/pkg/db/migrations/000016_obligation_categories.down.sql
+++ b/pkg/db/migrations/000016_obligation_categories.down.sql
@@ -1,0 +1,16 @@
+-- SPDX-FileCopyrightText: 2026 Siemens AG
+-- SPDX-FileContributor: Dearsh Oberoi <dearsh.oberoi@siemens.com>
+--
+-- SPDX-License-Identifier: GPL-2.0-only
+
+BEGIN;
+ALTER TABLE obligations ADD COLUMN category TEXT DEFAULT 'GENERAL'::text;
+UPDATE obligations
+    SET category = (
+        SELECT category FROM obligation_categories
+        WHERE obligation_categories.id = obligations.obligation_category_id
+    );
+ALTER TABLE obligations DROP CONSTRAINT fk_obligation_category;
+ALTER TABLE obligations DROP COLUMN obligation_category_id;
+DROP TABLE IF EXISTS obligation_categories;
+COMMIT;

--- a/pkg/db/migrations/000016_obligation_categories.up.sql
+++ b/pkg/db/migrations/000016_obligation_categories.up.sql
@@ -1,0 +1,28 @@
+-- SPDX-FileCopyrightText: 2026 Siemens AG
+-- SPDX-FileContributor: Dearsh Oberoi <dearsh.oberoi@siemens.com>
+--
+-- SPDX-License-Identifier: GPL-2.0-only
+
+BEGIN;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE IF NOT EXISTS obligation_categories (
+    id      UUID    NOT NULL PRIMARY KEY DEFAULT uuid_generate_v4(),
+    category TEXT   NOT NULL UNIQUE,
+    active  BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+INSERT INTO obligation_categories (category) VALUES
+    ('DISTRIBUTION'),
+    ('PATENT'),
+    ('INTERNAL'),
+    ('CONTRACTUAL'),
+    ('EXPORT_CONTROL'),
+    ('GENERAL')
+ON CONFLICT (category) DO NOTHING;
+
+ALTER TABLE obligations ADD COLUMN obligation_category_id UUID;
+ALTER TABLE obligations ADD CONSTRAINT fk_obligation_category FOREIGN KEY (obligation_category_id) REFERENCES obligation_categories(id);
+UPDATE obligations SET obligation_category_id = (SELECT id FROM obligation_categories WHERE obligation_categories.category = obligations.category);
+ALTER TABLE obligations DROP COLUMN category;
+COMMIT;

--- a/pkg/models/category.go
+++ b/pkg/models/category.go
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2026 Siemens AG
+// SPDX-FileContributor: Dearsh Oberoi <dearsh.oberoi@siemens.com>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+package models
+
+import "github.com/google/uuid"
+
+// ObligationCategory represents one of the possible of obligation category values
+type ObligationCategory struct {
+	Id       uuid.UUID `gorm:"type:uuid;primary_key;column:id;default:uuid_generate_v4()" json:"-"`
+	Category string    `gorm:"column:category" validate:"required,uppercase" example:"GENERAL" json:"category"`
+	Active   *bool     `gorm:"column:active;default:true" json:"-"`
+}
+
+func (ObligationCategory) TableName() string {
+	return "obligation_categories"
+}
+
+// ObligationCategoryResponse represents the response format for obligation category data.
+type ObligationCategoryResponse struct {
+	Status int                  `json:"status" example:"200"`
+	Data   []ObligationCategory `json:"data"`
+	Meta   *PaginationMeta      `json:"paginationmeta"`
+}

--- a/pkg/models/obligations.go
+++ b/pkg/models/obligations.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/google/uuid"
 	"gorm.io/datatypes"
@@ -29,36 +28,16 @@ type Obligation struct {
 	TextUpdatable              *bool                                         `gorm:"column:text_updatable;default:false"`
 	ObligationClassificationId uuid.UUID                                     `gorm:"type:uuid;column:obligation_classification_id"`
 	ObligationTypeId           uuid.UUID                                     `gorm:"type:uuid;column:obligation_type_id"`
+	ObligationCategoryId       uuid.UUID                                     `gorm:"type:uuid;column:obligation_category_id"`
 	Licenses                   []LicenseDB                                   `gorm:"many2many:obligation_licenses; joinForeignKey:obligation_id;joinReferences:license_db_id"`
 	Type                       *ObligationType                               `gorm:"foreignKey:ObligationTypeId;references:Id"`
 	Classification             *ObligationClassification                     `gorm:"foreignKey:ObligationClassificationId;references:Id"`
-	Category                   *string                                       `json:"category" gorm:"default:GENERAL" enums:"DISTRIBUTION,PATENT,INTERNAL,CONTRACTUAL,EXPORT_CONTROL,GENERAL" example:"DISTRIBUTION"`
+	Category                   *ObligationCategory                           `gorm:"foreignKey:ObligationCategoryId;references:Id"`
 	ExternalRef                datatypes.JSONType[ObligationSchemaExtension] `gorm:"column:external_ref"`
 }
 
 func (Obligation) TableName() string {
 	return "obligations"
-}
-
-var validCategories = []string{"DISTRIBUTION", "PATENT", "INTERNAL", "CONTRACTUAL", "EXPORT_CONTROL", "GENERAL"}
-
-func validateCategory(o *Obligation) error {
-	// Check if the provided category is in the list of valid categories. Nil value allowed, will default to GENERAL
-	if o.Category == nil {
-		return nil
-	}
-	allCategories := strings.Join(validCategories, ", ")
-	categoryValid := false
-	for _, cat := range validCategories {
-		if *o.Category == cat {
-			categoryValid = true
-			break
-		}
-	}
-	if !categoryValid {
-		return fmt.Errorf("category must be one of the following values: %s", allCategories)
-	}
-	return nil
 }
 
 func (o *Obligation) BeforeCreate(tx *gorm.DB) (err error) {
@@ -116,8 +95,25 @@ func (o *Obligation) BeforeCreate(tx *gorm.DB) (err error) {
 		return errors.New("classification cannot be empty")
 	}
 
-	if err := validateCategory(o); err != nil {
-		return err
+	if o.Category != nil {
+		var obCategories []ObligationCategory
+		if err := tx.Find(&obCategories).Error; err != nil {
+			return err
+		}
+		allCategories := ""
+		for i := 0; i < len(obCategories); i++ {
+			if *obCategories[i].Active {
+				allCategories += fmt.Sprintf(" %s", obCategories[i].Category)
+				if o.Category.Category == obCategories[i].Category {
+					o.Category = &obCategories[i]
+				}
+			}
+		}
+		if o.Classification.Id.String() == "" {
+			return fmt.Errorf("obligation category must be one of the following values:%s", allCategories)
+		}
+	} else {
+		return errors.New("category cannot be empty")
 	}
 
 	return nil
@@ -167,9 +163,23 @@ func (o *Obligation) BeforeUpdate(tx *gorm.DB) (err error) {
 			return fmt.Errorf("obligation classification must be one of the following values:%s", allClassifications)
 		}
 	}
-
-	if err := validateCategory(o); err != nil {
-		return err
+	if o.Category != nil {
+		var obCategories []ObligationCategory
+		if err := tx.Find(&obCategories).Error; err != nil {
+			return err
+		}
+		allCategories := ""
+		for i := 0; i < len(obCategories); i++ {
+			if *obCategories[i].Active {
+				allCategories += fmt.Sprintf(" %s", obCategories[i].Category)
+				if o.Category.Category == obCategories[i].Category {
+					o.Category = &obCategories[i]
+				}
+			}
+		}
+		if o.Classification.Id.String() == "" {
+			return fmt.Errorf("obligation category must be one of the following values:%s", allCategories)
+		}
 	}
 
 	return nil
@@ -185,15 +195,9 @@ func (o *Obligation) ConvertToObligationResponseDTO() ObligationResponseDTO {
 		LicenseIds:     []uuid.UUID{},
 		Type:           o.Type.Type,
 		Classification: o.Classification.Classification,
+		Category:       o.Category.Category,
 		Comment:        o.Comment,
 		ExternalRef:    o.ExternalRef.Data(),
-	}
-
-	if o.Category != nil && *o.Category != "" {
-		dto.Category = o.Category
-	} else {
-		category := "GENERAL"
-		dto.Category = &category
 	}
 
 	for _, lic := range o.Licenses {
@@ -214,7 +218,7 @@ type ObligationResponseDTO struct {
 	Active         bool                      `json:"active"`
 	TextUpdatable  bool                      `json:"text_updatable" example:"true"`
 	LicenseIds     []uuid.UUID               `json:"license_ids" validate:"required" swaggertype:"array,string" example:"f81d4fae-7dec-11d0-a765-00a0c91e6bf6,f812jfae-7dbc-11d0-a765-00a0hf06bf6"`
-	Category       *string                   `json:"category" example:"DISTRIBUTION" validate:"required"`
+	Category       string                    `json:"category" example:"DISTRIBUTION" validate:"required"`
 	ExternalRef    ObligationSchemaExtension `json:"external_ref"`
 }
 
@@ -246,7 +250,9 @@ func (obDto *ObligationUpdateDTO) ConvertToObligation() Obligation {
 	o.Comment = obDto.Comment
 	o.Active = obDto.Active
 	o.TextUpdatable = obDto.TextUpdatable
-	o.Category = obDto.Category
+	if obDto.Category != nil {
+		o.Category = &ObligationCategory{Category: *obDto.Category}
+	}
 
 	return o
 }
@@ -261,7 +267,7 @@ type ObligationCreateDTO struct {
 	Active         *bool                     `json:"active"`
 	TextUpdatable  *bool                     `json:"text_updatable" example:"true"`
 	LicenseIds     []uuid.UUID               `json:"license_ids" validate:"required" swaggertype:"array,string" example:"f81d4fae-7dec-11d0-a765-00a0c91e6bf6,f812jfae-7dbc-11d0-a765-00a0hf06bf6"`
-	Category       *string                   `json:"category" example:"DISTRIBUTION"`
+	Category       string                    `json:"category" example:"DISTRIBUTION"`
 	ExternalRef    ObligationSchemaExtension `json:"external_ref"`
 }
 
@@ -273,7 +279,9 @@ func (dto *ObligationCreateDTO) ConvertToObligation() Obligation {
 	o.Comment = dto.Comment
 	o.Active = dto.Active
 	o.TextUpdatable = dto.TextUpdatable
-	o.Category = dto.Category
+	o.Category = &ObligationCategory{
+		Category: dto.Category,
+	}
 
 	o.Type = &ObligationType{
 		Type: dto.Type,
@@ -319,7 +327,9 @@ func (obDto *ObligationFileDTO) ConvertToObligation() Obligation {
 	o.Comment = obDto.Comment
 	o.Active = obDto.Active
 	o.TextUpdatable = obDto.TextUpdatable
-	o.Category = obDto.Category
+	if obDto.Category != nil {
+		o.Category = &ObligationCategory{Category: *obDto.Category}
+	}
 
 	var ext ObligationSchemaExtension
 

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -342,14 +342,14 @@ func PerformLicenseMapActions(tx *gorm.DB, userId uuid.UUID, license *models.Lic
 	for _, obId := range newObligationIds {
 		var ob models.Obligation
 		activeStatus := true
-		if err := tx.Where(models.Obligation{Id: obId, Active: &activeStatus}).Preload("Classification").Preload("Type").First(&ob).Error; err != nil {
+		if err := tx.Where(models.Obligation{Id: obId, Active: &activeStatus}).Preload("Classification").Preload("Category").Preload("Type").First(&ob).Error; err != nil {
 			errs = append(errs, fmt.Errorf("unable to associate obligation '%s': %s", obId, err.Error()))
 		} else {
 			newObligationAssociations = append(newObligationAssociations, ob)
 		}
 	}
 
-	if err := tx.Debug().Model(license).Association("Obligations").Replace(newObligationAssociations); err != nil {
+	if err := tx.Model(license).Association("Obligations").Replace(newObligationAssociations); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -411,6 +411,28 @@ func AddChangelogForObligationClassification(tx *gorm.DB, userId uuid.UUID, oldO
 	return nil
 }
 
+func AddChangelogForObligationCategory(tx *gorm.DB, userId uuid.UUID, oldObCategory, newObCategory *models.ObligationCategory) error {
+	var changes []models.ChangeLog
+	AddChangelog("Active", oldObCategory.Active, newObCategory.Active, &changes)
+	AddChangelog("Category", &oldObCategory.Category, &newObCategory.Category, &changes)
+
+	if len(changes) != 0 {
+		audit := models.Audit{
+			UserId:     userId,
+			TypeId:     newObCategory.Id,
+			Timestamp:  time.Now(),
+			Type:       "CATEGORY",
+			ChangeLogs: changes,
+		}
+
+		if err := tx.Create(&audit).Error; err != nil {
+			return errors.New("unable to update obligation category")
+		}
+	}
+
+	return nil
+}
+
 func ToggleObligationClassificationActiveStatus(userId uuid.UUID, tx *gorm.DB, obClassification *models.ObligationClassification) error {
 	newObClassification := *obClassification
 	newActive := !*obClassification.Active
@@ -420,6 +442,17 @@ func ToggleObligationClassificationActiveStatus(userId uuid.UUID, tx *gorm.DB, o
 	}
 
 	return AddChangelogForObligationClassification(tx, userId, obClassification, &newObClassification)
+}
+
+func ToggleObligationCategoryActiveStatus(userId uuid.UUID, tx *gorm.DB, obCategory *models.ObligationCategory) error {
+	newObCategory := *obCategory
+	newActive := !*obCategory.Active
+	newObCategory.Active = &newActive
+	if err := tx.Clauses(clause.Returning{}).Updates(&newObCategory).Error; err != nil {
+		return errors.New("unable to change 'active' status of obligation type")
+	}
+
+	return AddChangelogForObligationCategory(tx, userId, obCategory, &newObCategory)
 }
 
 // ObligationTypeStatusCode is internally used for checking status of a obligation type creation
@@ -504,6 +537,41 @@ func CreateObClassification(obClassification *models.ObligationClassification, u
 	return err, status
 }
 
+func CreateObCategory(obCategory *models.ObligationCategory, userId uuid.UUID) (error, ObligationFieldCreateStatusCode) {
+	if err := validations.Validate.Struct(obCategory); err != nil {
+		return err, VALIDATION_FAILED
+	}
+
+	var status ObligationFieldCreateStatusCode
+	err := db.DB.Transaction(func(tx *gorm.DB) error {
+		result := tx.Where(&models.ObligationCategory{Category: obCategory.Category}).FirstOrCreate(&obCategory)
+		if result.Error != nil {
+			status = CREATE_FAILED
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			if *obCategory.Active {
+				status = CONFLICT
+				return errors.New("obligation category already exists")
+			}
+			if err := ToggleObligationCategoryActiveStatus(userId, tx, obCategory); err != nil {
+				status = CONFLICT_ACTIVATION_FAILED
+				return err
+			}
+		} else {
+			if err := AddChangelogForObligationCategory(tx, userId, &models.ObligationCategory{}, obCategory); err != nil {
+				status = CREATE_FAILED
+				return err
+			}
+		}
+
+		status = CREATED
+		return nil
+	})
+
+	return err, status
+}
+
 // Populatedb populates the database with license data from a JSON file.
 func Populatedb(datafile string) {
 	var licenses []models.LicenseJson
@@ -575,6 +643,29 @@ func Populatedb(datafile string) {
 			log.Printf("%s%s: %s%s", red, obClassification.Classification, err.Error(), reset)
 		}
 	}
+
+	DEFAULT_OBLIGATION_CATEGORIES := []*models.ObligationCategory{
+		{Category: "DISTRIBUTION"},
+		{Category: "PATENT"},
+		{Category: "INTERNAL"},
+		{Category: "CONTRACTUAL"},
+		{Category: "EXPORT_CONTROL"},
+		{Category: "GENERAL"},
+	}
+
+	for _, obCategory := range DEFAULT_OBLIGATION_CATEGORIES {
+		err, status := CreateObCategory(obCategory, user.Id)
+
+		if status == CREATED || status == CONFLICT {
+			green := "\033[32m"
+			reset := "\033[0m"
+			log.Printf("%s%s: %s%s", green, obCategory.Category, "Obligation category created successfully", reset)
+		} else {
+			red := "\033[31m"
+			reset := "\033[0m"
+			log.Printf("%s%s: %s%s", red, obCategory.Category, err.Error(), reset)
+		}
+	}
 }
 
 // SetSimilarityThreshold parses the env var and sets the threshold in Postgres.
@@ -618,7 +709,7 @@ func GetAuditEntity(c *gin.Context, audit *models.Audit) error {
 		audit.Entity = lic.ConvertToLicenseResponseDTO()
 	case "OBLIGATION":
 		var ob models.Obligation
-		if err := db.DB.Joins("Type").Joins("Classification").Where(&models.Obligation{Id: audit.TypeId}).First(&ob).Error; err != nil {
+		if err := db.DB.Joins("Type").Joins("Classification").Joins("Category").Where(&models.Obligation{Id: audit.TypeId}).First(&ob).Error; err != nil {
 			er := models.LicenseError{
 				Status:    http.StatusNotFound,
 				Message:   "obligation corresponding with this audit does not exist",
@@ -649,6 +740,19 @@ func GetAuditEntity(c *gin.Context, audit *models.Audit) error {
 			er := models.LicenseError{
 				Status:    http.StatusNotFound,
 				Message:   "obligation classification corresponding with this audit does not exist",
+				Error:     err.Error(),
+				Path:      c.Request.URL.Path,
+				Timestamp: time.Now().Format(time.RFC3339),
+			}
+			c.JSON(http.StatusNotFound, er)
+			return err
+		}
+	case "CATEGORY":
+		audit.Entity = &models.ObligationCategory{}
+		if err := db.DB.Where(&models.ObligationCategory{Id: audit.TypeId}).First(&audit.Entity).Error; err != nil {
+			er := models.LicenseError{
+				Status:    http.StatusNotFound,
+				Message:   "obligation category corresponding with this audit does not exist",
 				Error:     err.Error(),
 				Path:      c.Request.URL.Path,
 				Timestamp: time.Now().Format(time.RFC3339),

--- a/tests/licenses_comprehensive_test.go
+++ b/tests/licenses_comprehensive_test.go
@@ -240,7 +240,7 @@ func TestImportLicenses(t *testing.T) {
 			Comment:        ptr("try to link obligations to a license in POST request"),
 			Active:         ptr(true),
 			TextUpdatable:  ptr(false),
-			Category:       ptr("GENERAL"),
+			Category:       "GENERAL",
 			ExternalRef: models.ObligationSchemaExtension{
 				ObligationExplanation: ptr("this is a test explaination to test the external ref functionality"),
 			},
@@ -307,7 +307,7 @@ func TestImportLicenses(t *testing.T) {
 			Comment:        ptr("try to link obligations to a license in POST request"),
 			Active:         ptr(true),
 			TextUpdatable:  ptr(false),
-			Category:       ptr("GENERAL"),
+			Category:       "GENERAL",
 			ExternalRef: models.ObligationSchemaExtension{
 				ObligationExplanation: ptr("this is a test explaination to test the external ref functionality"),
 			},
@@ -396,7 +396,7 @@ func TestImportLicenses(t *testing.T) {
 			Comment:        ptr("try to link obligations to a license in POST request"),
 			Active:         ptr(true),
 			TextUpdatable:  ptr(false),
-			Category:       ptr("GENERAL"),
+			Category:       "GENERAL",
 			ExternalRef: models.ObligationSchemaExtension{
 				ObligationExplanation: ptr("this is a test explaination to test the external ref functionality"),
 			},

--- a/tests/licenses_test.go
+++ b/tests/licenses_test.go
@@ -95,7 +95,7 @@ func TestCreateLicense(t *testing.T) {
 			Comment:        ptr("try to link obligations to a license in POST request"),
 			Active:         ptr(true),
 			TextUpdatable:  ptr(false),
-			Category:       ptr("GENERAL"),
+			Category:       "GENERAL",
 			ExternalRef: models.ObligationSchemaExtension{
 				ObligationExplanation: ptr("this is a test explaination to test the external ref functionality"),
 			},
@@ -289,7 +289,7 @@ func TestUpdateLicense(t *testing.T) {
 			Comment:        ptr("try to link obligations to a license in POST request"),
 			Active:         ptr(true),
 			TextUpdatable:  ptr(false),
-			Category:       ptr("GENERAL"),
+			Category:       "GENERAL",
 			ExternalRef: models.ObligationSchemaExtension{
 				ObligationExplanation: ptr("this is a test explaination to test the external ref functionality"),
 			},

--- a/tests/obligation_categories_test.go
+++ b/tests/obligation_categories_test.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 Siemens AG
+// SPDX-FileContributor: Dearsh Oberoi <dearsh.oberoi@siemens.com>
+//
+// SPDX-License-Identifier: GPL-2.0-only
+
+package test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/fossology/LicenseDb/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateObligationCategory(t *testing.T) {
+	loginAs(t, "admin")
+
+	obCategory := models.ObligationCategory{
+		Category: "GENERAL-II",
+		Active:   ptr(true),
+	}
+
+	t.Run("success", func(t *testing.T) {
+		w := makeRequest("POST", "/obligations/categories", obCategory, true)
+		assert.Equal(t, http.StatusCreated, w.Code)
+
+		var res models.ObligationCategoryResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+			t.Errorf("Error unmarshalling response: %v", err)
+			return
+		}
+		assert.Equal(t, obCategory.Category, res.Data[0].Category)
+	})
+
+	t.Run("missingFields", func(t *testing.T) {
+		invalidObCategory := models.ObligationCategory{
+			Category: "",
+			Active:   ptr(true),
+		}
+		w := makeRequest("POST", "/obligations/categories", invalidObCategory, true)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("unauthorized", func(t *testing.T) {
+		w := makeRequest("POST", "/obligations/categories", obCategory, false)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("duplicateObligationCategory", func(t *testing.T) {
+		duplicate := models.ObligationCategory{
+			Category: "DUPLICATE",
+			Active:   ptr(true),
+		}
+
+		w1 := makeRequest("POST", "/obligations/categories", duplicate, true)
+		assert.Equal(t, http.StatusCreated, w1.Code)
+
+		w2 := makeRequest("POST", "/obligations/categories", duplicate, true)
+		assert.Equal(t, http.StatusConflict, w2.Code)
+	})
+}
+
+// TestGetAllObligationCategory tests the GET /obligations/categories API
+func TestGetAllObligationCategory(t *testing.T) {
+	t.Run("getAllActive", func(t *testing.T) {
+		w := makeRequest("GET", "/obligations/categories?active=true", nil, true)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var res models.ObligationCategoryResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+			t.Errorf("Error unmarshalling response: %v", err)
+			return
+		}
+		assert.GreaterOrEqual(t, len(res.Data), 0)
+	})
+
+	t.Run("invalidQueryParam", func(t *testing.T) {
+		w := makeRequest("GET", "/obligations/categories?active=invalid", nil, true)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}
+
+func TestDeleteObligationCategory(t *testing.T) {
+	obCategory := models.ObligationCategory{
+		Category: "TODELETE",
+		Active:   ptr(true),
+	}
+	w := makeRequest("POST", "/obligations/categories", obCategory, true)
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	t.Run("success", func(t *testing.T) {
+		w := makeRequest("DELETE", "/obligations/categories/"+obCategory.Category, nil, true)
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("notFound", func(t *testing.T) {
+		w := makeRequest("DELETE", "/obligations/categories/NonExistentCategory", nil, true)
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("unauthorized", func(t *testing.T) {
+		w := makeRequest("DELETE", "/obligations/categories/"+obCategory.Category, nil, false)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+}

--- a/tests/obligations_comprehensive_test.go
+++ b/tests/obligations_comprehensive_test.go
@@ -69,7 +69,7 @@ func TestGetObligation(t *testing.T) {
 		Comment:        ptr("Test comment"),
 		Active:         ptr(true),
 		TextUpdatable:  ptr(false),
-		Category:       ptr("GENERAL"),
+		Category:       "GENERAL",
 	}
 	createW := makeRequest("POST", "/obligations", dto, true)
 	assert.Equal(t, http.StatusCreated, createW.Code)
@@ -137,7 +137,7 @@ func TestGetObligationAudits(t *testing.T) {
 		Comment:        ptr("Test comment"),
 		Active:         ptr(true),
 		TextUpdatable:  ptr(false),
-		Category:       ptr("GENERAL"),
+		Category:       "GENERAL",
 	}
 	createW := makeRequest("POST", "/obligations", dto, true)
 	assert.Equal(t, http.StatusCreated, createW.Code)
@@ -376,7 +376,7 @@ func TestImportObligations(t *testing.T) {
 			Comment:        ptr("unit test comment"),
 			Active:         ptr(true),
 			TextUpdatable:  ptr(false),
-			Category:       ptr("GENERAL"),
+			Category:       "GENERAL",
 			ExternalRef: models.ObligationSchemaExtension{
 				ObligationExplanation: ptr("this is a test explaination to test the external ref functionality"),
 			},

--- a/tests/obligations_test.go
+++ b/tests/obligations_test.go
@@ -26,7 +26,7 @@ func TestCreateObligation(t *testing.T) {
 			Comment:        ptr("unit test no license ids"),
 			Active:         ptr(true),
 			TextUpdatable:  ptr(false),
-			Category:       ptr("GENERAL"),
+			Category:       "GENERAL",
 			ExternalRef: models.ObligationSchemaExtension{
 				ObligationExplanation: ptr("this is a test explaination to test the external ref functionality"),
 			},
@@ -54,7 +54,7 @@ func TestCreateObligation(t *testing.T) {
 			Active:         ptr(true),
 			TextUpdatable:  ptr(true),
 			LicenseIds:     []uuid.UUID{res.Data[0].Id},
-			Category:       ptr("DISTRIBUTION"),
+			Category:       "DISTRIBUTION",
 			ExternalRef: models.ObligationSchemaExtension{
 				ObligationExplanation: ptr("this is a test explaination to test the external ref functionality"),
 			},
@@ -72,7 +72,7 @@ func TestCreateObligation(t *testing.T) {
 			Active:         ptr(true),
 			TextUpdatable:  ptr(false),
 			LicenseIds:     []uuid.UUID{uuid.New()},
-			Category:       ptr("GENERAL"),
+			Category:       "GENERAL",
 		}
 
 		w := makeRequest("POST", "/obligations", dto, true)
@@ -97,7 +97,7 @@ func TestCreateObligation(t *testing.T) {
 			Comment:        ptr("missing topic"),
 			Active:         ptr(true),
 			TextUpdatable:  ptr(false),
-			Category:       ptr("GENERAL"),
+			Category:       "GENERAL",
 		}
 
 		w := makeRequest("POST", "/obligations", dto, true)
@@ -119,7 +119,7 @@ func TestUpdateObligation(t *testing.T) {
 			Comment:        ptr("unit test comment"),
 			Active:         ptr(true),
 			TextUpdatable:  ptr(false),
-			Category:       ptr("GENERAL"),
+			Category:       "GENERAL",
 			ExternalRef: models.ObligationSchemaExtension{
 				ObligationExplanation: ptr("this is a test explaination to test the external ref functionality"),
 			},
@@ -255,7 +255,7 @@ func TestDeleteObligation(t *testing.T) {
 		Comment:        ptr("delete comment"),
 		Active:         ptr(true),
 		TextUpdatable:  ptr(true),
-		Category:       ptr("GENERAL"),
+		Category:       "GENERAL",
 	}
 	_id = assertObligationCreated(t, dto)
 	id := _id.String()
@@ -310,12 +310,7 @@ func assertObligationCreated(t *testing.T, dto models.ObligationCreateDTO) uuid.
 	if ob.Comment != nil {
 		assertField("Comment", *dto.Comment, *ob.Comment)
 	}
-	if ob.Category != nil {
-		assertField("Category", *dto.Category, *ob.Category)
-	} else {
-		assertField("Category", *dto.Category, "GENERAL")
-	}
-
+	assertField("Category", dto.Category, ob.Category)
 	assertField("Classification", dto.Classification, ob.Classification)
 	assertField("Active", *dto.Active, ob.Active)
 	assertField("TextUpdatable", *dto.TextUpdatable, ob.TextUpdatable)
@@ -389,7 +384,7 @@ func assertObligationUpdated(t *testing.T, id uuid.UUID, dto models.ObligationUp
 		assertField("Comment", *dto.Comment, *ob.Comment)
 	}
 	if dto.Category != nil {
-		assertField("Category", *dto.Category, *ob.Category)
+		assertField("Category", *dto.Category, ob.Category)
 	}
 	if dto.Classification != nil {
 		assertField("Classification", *dto.Classification, ob.Classification)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 Avinal Kumar <avinal.xlvii@gmail.com>
SPDX-License-Identifier: GPL-2.0-only

Thank you for the pull request. Please fill this template as much as
possible and delete unused parts.
-->

## Changes

<!-- Describe your changes here. Ideally GitHub can get the description
from your descriptive commit message(s). Link issues/PR that are relevant
for your changes.-->

- Made obligation category  values configurable by the admin. Added crud endpoints for category and fixed other endpoints for new changes.


## Submitter Checklist

- [X] Includes tests (if there is a feature changed/added)
- [X] Includes docs ( if changes are user facing)
- [X] I have tested my changes locally.

## How to Test
1. Go to swagger docs and create an auth token for admin user.
2. Try the endpoint ```GET /obligations/categories```. It should fetch a default set of categories.
3.  Try to add a new category via the endpoint ```POST /obligations/categories```.
4. Try the endpoint ```GET /obligations/categories```. It should have the newly created category.
5.  Try to deletre a category via the endpoint ```DELETE /obligations/categories```.
6. Try the endpoint ```GET /obligations/categories```. It should not have the deleted category.
7. Create an auth token for non-admin user. Try the above endpoints. They should not work.
