### PR TITLE
fix(migrations): clean up category audit logs on down migration

### DIFF
--- a/pkg/db/migrations/000016_obligation_categories.down.sql
+++ b/pkg/db/migrations/000016_obligation_categories.down.sql
@@ -12,5 +12,9 @@ UPDATE obligations
     );
 ALTER TABLE obligations DROP CONSTRAINT fk_obligation_category;
 ALTER TABLE obligations DROP COLUMN obligation_category_id;
+
+DELETE FROM change_logs WHERE audit_id IN (SELECT id FROM audits WHERE type = 'CATEGORY');
+DELETE FROM audits WHERE type = 'CATEGORY';
+
 DROP TABLE IF EXISTS obligation_categories;
 COMMIT;


### PR DESCRIPTION
## Changes

- Fix missing cleanup of polymorphic audit and change logs where `type = 'CATEGORY'` in the `000016_obligation_categories` down migration.
- Add `DELETE` statements before dropping `obligation_categories` to prevent dangling records and referential inconsistency.
- Fixes #212

## Submitter Checklist

- [ ] Includes tests (if there is a feature changed/added)
- [ ] Includes docs ( if changes are user facing)
- [x] I have tested my changes locally.

## References

**Context**: The `000016_obligation_categories` down migration rolls back configurable categories by dropping the `obligation_categories` table. However, it fails to clean up polymorphic records in `audits` (and referencing `change_logs`) where `type = 'CATEGORY'`. This leaves dangling log entries that reference non-existent entities, polluting the database state on rollback.