### PR TITLE
feat(search): add fuzzy search with ranking to GET /licenses and GET /obligations

### DIFF
--- a/cmd/laas/docs/docs.go
+++ b/cmd/laas/docs/docs.go
@@ -343,7 +343,7 @@ const docTemplate = `{
                         "{}": []
                     }
                 ],
-                "description": "Filter licenses based on different parameters",
+                "description": "Filter licenses based on different parameters. The ` + "`" + `search` + "`" + ` parameter does a fuzzy match against the spdx_id, fullname, shortname and text fields, with results ranked so spdx_id matches come before fullname matches, which come before shortname matches, which come before text matches.",
                 "consumes": [
                     "application/json"
                 ],
@@ -378,6 +378,12 @@ const docTemplate = `{
                         "type": "boolean",
                         "description": "Copyleft flag status of license",
                         "name": "copyleft",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fuzzy search text matched against spdx_id, fullname, shortname and text fields (ranked spdx_id \u003e fullname \u003e shortname \u003e text)",
+                        "name": "search",
                         "in": "query"
                     },
                     {
@@ -852,7 +858,7 @@ const docTemplate = `{
                         "{}": []
                     }
                 ],
-                "description": "Get all active obligations from the service",
+                "description": "Get all active obligations from the service. The ` + "`" + `search` + "`" + ` parameter does a fuzzy match against the topic and text fields, with results ranked so topic matches come before text matches.",
                 "consumes": [
                     "application/json"
                 ],
@@ -871,6 +877,12 @@ const docTemplate = `{
                         "name": "active",
                         "in": "query",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fuzzy search text matched against topic and text fields (ranked topic \u003e text)",
+                        "name": "search",
+                        "in": "query"
                     },
                     {
                         "type": "integer",
@@ -2004,59 +2016,6 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Invalid or expired refresh token",
-                        "schema": {
-                            "$ref": "#/definitions/models.LicenseError"
-                        }
-                    }
-                }
-            }
-        },
-        "/search": {
-            "post": {
-                "security": [
-                    {
-                        "ApiKeyAuth": [],
-                        "{}": []
-                    }
-                ],
-                "description": "Search licenses on different filters and algorithms",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Licenses"
-                ],
-                "summary": "Search licenses",
-                "operationId": "SearchInLicense",
-                "parameters": [
-                    {
-                        "description": "Search criteria",
-                        "name": "search",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.SearchLicense"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Licenses matched",
-                        "schema": {
-                            "$ref": "#/definitions/models.LicenseResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request",
-                        "schema": {
-                            "$ref": "#/definitions/models.LicenseError"
-                        }
-                    },
-                    "404": {
-                        "description": "Search algorithm doesn't exist",
                         "schema": {
                             "$ref": "#/definitions/models.LicenseError"
                         }
@@ -3446,30 +3405,6 @@ const docTemplate = `{
                 "risk": {
                     "type": "integer",
                     "example": 2
-                }
-            }
-        },
-        "models.SearchLicense": {
-            "type": "object",
-            "required": [
-                "field",
-                "search_term"
-            ],
-            "properties": {
-                "field": {
-                    "type": "string",
-                    "example": "text"
-                },
-                "search": {
-                    "type": "string",
-                    "enum": [
-                        "fuzzy",
-                        "full_text_search"
-                    ]
-                },
-                "search_term": {
-                    "type": "string",
-                    "example": "MIT License"
                 }
             }
         },

--- a/cmd/laas/docs/swagger.json
+++ b/cmd/laas/docs/swagger.json
@@ -336,7 +336,7 @@
                         "{}": []
                     }
                 ],
-                "description": "Filter licenses based on different parameters",
+                "description": "Filter licenses based on different parameters. The `search` parameter does a fuzzy match against the spdx_id, fullname, shortname and text fields, with results ranked so spdx_id matches come before fullname matches, which come before shortname matches, which come before text matches.",
                 "consumes": [
                     "application/json"
                 ],
@@ -371,6 +371,12 @@
                         "type": "boolean",
                         "description": "Copyleft flag status of license",
                         "name": "copyleft",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fuzzy search text matched against spdx_id, fullname, shortname and text fields (ranked spdx_id \u003e fullname \u003e shortname \u003e text)",
+                        "name": "search",
                         "in": "query"
                     },
                     {
@@ -845,7 +851,7 @@
                         "{}": []
                     }
                 ],
-                "description": "Get all active obligations from the service",
+                "description": "Get all active obligations from the service. The `search` parameter does a fuzzy match against the topic and text fields, with results ranked so topic matches come before text matches.",
                 "consumes": [
                     "application/json"
                 ],
@@ -864,6 +870,12 @@
                         "name": "active",
                         "in": "query",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Fuzzy search text matched against topic and text fields (ranked topic \u003e text)",
+                        "name": "search",
+                        "in": "query"
                     },
                     {
                         "type": "integer",
@@ -1997,59 +2009,6 @@
                     },
                     "401": {
                         "description": "Invalid or expired refresh token",
-                        "schema": {
-                            "$ref": "#/definitions/models.LicenseError"
-                        }
-                    }
-                }
-            }
-        },
-        "/search": {
-            "post": {
-                "security": [
-                    {
-                        "ApiKeyAuth": [],
-                        "{}": []
-                    }
-                ],
-                "description": "Search licenses on different filters and algorithms",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Licenses"
-                ],
-                "summary": "Search licenses",
-                "operationId": "SearchInLicense",
-                "parameters": [
-                    {
-                        "description": "Search criteria",
-                        "name": "search",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/models.SearchLicense"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Licenses matched",
-                        "schema": {
-                            "$ref": "#/definitions/models.LicenseResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request",
-                        "schema": {
-                            "$ref": "#/definitions/models.LicenseError"
-                        }
-                    },
-                    "404": {
-                        "description": "Search algorithm doesn't exist",
                         "schema": {
                             "$ref": "#/definitions/models.LicenseError"
                         }
@@ -3439,30 +3398,6 @@
                 "risk": {
                     "type": "integer",
                     "example": 2
-                }
-            }
-        },
-        "models.SearchLicense": {
-            "type": "object",
-            "required": [
-                "field",
-                "search_term"
-            ],
-            "properties": {
-                "field": {
-                    "type": "string",
-                    "example": "text"
-                },
-                "search": {
-                    "type": "string",
-                    "enum": [
-                        "fuzzy",
-                        "full_text_search"
-                    ]
-                },
-                "search_term": {
-                    "type": "string",
-                    "example": "MIT License"
                 }
             }
         },

--- a/cmd/laas/docs/swagger.yaml
+++ b/cmd/laas/docs/swagger.yaml
@@ -710,23 +710,6 @@ definitions:
         example: 2
         type: integer
     type: object
-  models.SearchLicense:
-    properties:
-      field:
-        example: text
-        type: string
-      search:
-        enum:
-        - fuzzy
-        - full_text_search
-        type: string
-      search_term:
-        example: MIT License
-        type: string
-    required:
-    - field
-    - search_term
-    type: object
   models.SimilarLicense:
     properties:
       id:
@@ -1093,7 +1076,10 @@ paths:
     get:
       consumes:
       - application/json
-      description: Filter licenses based on different parameters
+      description: Filter licenses based on different parameters. The `search` parameter
+        does a fuzzy match against the spdx_id, fullname, shortname and text fields,
+        with results ranked so spdx_id matches come before fullname matches, which
+        come before shortname matches, which come before text matches.
       operationId: FilterLicense
       parameters:
       - description: SPDX ID of the license
@@ -1112,6 +1098,11 @@ paths:
         in: query
         name: copyleft
         type: boolean
+      - description: Fuzzy search text matched against spdx_id, fullname, shortname
+          and text fields (ranked spdx_id > fullname > shortname > text)
+        in: query
+        name: search
+        type: string
       - description: Page number
         in: query
         name: page
@@ -1421,7 +1412,9 @@ paths:
     get:
       consumes:
       - application/json
-      description: Get all active obligations from the service
+      description: Get all active obligations from the service. The `search` parameter
+        does a fuzzy match against the topic and text fields, with results ranked
+        so topic matches come before text matches.
       operationId: GetAllObligation
       parameters:
       - description: Active obligation only
@@ -1429,6 +1422,11 @@ paths:
         name: active
         required: true
         type: boolean
+      - description: Fuzzy search text matched against topic and text fields (ranked
+          topic > text)
+        in: query
+        name: search
+        type: string
       - description: Page number
         in: query
         name: page
@@ -2171,40 +2169,6 @@ paths:
       summary: Verify refresh token
       tags:
       - Users
-  /search:
-    post:
-      consumes:
-      - application/json
-      description: Search licenses on different filters and algorithms
-      operationId: SearchInLicense
-      parameters:
-      - description: Search criteria
-        in: body
-        name: search
-        required: true
-        schema:
-          $ref: '#/definitions/models.SearchLicense'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: Licenses matched
-          schema:
-            $ref: '#/definitions/models.LicenseResponse'
-        "400":
-          description: Invalid request
-          schema:
-            $ref: '#/definitions/models.LicenseError'
-        "404":
-          description: Search algorithm doesn't exist
-          schema:
-            $ref: '#/definitions/models.LicenseError'
-      security:
-      - '{}': []
-        ApiKeyAuth: []
-      summary: Search licenses
-      tags:
-      - Licenses
   /users:
     get:
       consumes:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -123,10 +123,6 @@ func Router() *gin.Engine {
 				licenses.POST("/similarity", getSimilarLicenses)
 
 			}
-			search := authorizedv1.Group("/search")
-			{
-				search.POST("", SearchInLicense)
-			}
 			users := authorizedv1.Group("/users")
 			{
 				users.GET("", middleware.RoleBasedAccessMiddleware([]string{"ADMIN", "SUPER_ADMIN"}), auth.GetAllUser)
@@ -186,10 +182,6 @@ func Router() *gin.Engine {
 				licenses.GET(":id", GetLicense)
 				licenses.GET("export", ExportLicenses)
 				licenses.GET("/preview", GetAllLicensePreviews)
-			}
-			search := unAuthorizedv1.Group("/search")
-			{
-				search.POST("", SearchInLicense)
 			}
 			obligations := unAuthorizedv1.Group("/obligations")
 			{

--- a/pkg/api/licenses.go
+++ b/pkg/api/licenses.go
@@ -29,12 +29,13 @@ import (
 	"github.com/google/uuid"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // FilterLicense Get licenses from service based on different filters.
 //
 //	@Summary		Filter licenses
-//	@Description	Filter licenses based on different parameters
+//	@Description	Filter licenses based on different parameters. The `search` parameter does a fuzzy match against the spdx_id, fullname, shortname and text fields, with results ranked so spdx_id matches come before fullname matches, which come before shortname matches, which come before text matches.
 //	@Id				FilterLicense
 //	@Tags			Licenses
 //	@Accept			json
@@ -43,6 +44,7 @@ import (
 //	@Param			active		query		bool					false	"Active license only"
 //	@Param			osiapproved	query		bool					false	"OSI Approved flag status of license"
 //	@Param			copyleft	query		bool					false	"Copyleft flag status of license"
+//	@Param			search		query		string					false	"Fuzzy search text matched against spdx_id, fullname, shortname and text fields (ranked spdx_id > fullname > shortname > text)"
 //	@Param			page		query		int						false	"Page number"
 //	@Param			limit		query		int						false	"Limit of responses per page"
 //	@Param			externalRef	query		string					false	"External reference parameters"
@@ -58,6 +60,7 @@ func FilterLicense(c *gin.Context) {
 	OSIapproved := c.Query("osiapproved")
 	copyleft := c.Query("copyleft")
 	externalRef := c.Query("externalRef")
+	searchTerm := strings.TrimSpace(c.Query("search"))
 
 	externalRefData := make(map[string]string)
 
@@ -111,6 +114,15 @@ func FilterLicense(c *gin.Context) {
 		query = query.Where(fmt.Sprintf("external_ref->>'%s' = ?", externalRefKey), externalRefValue)
 	}
 
+	var likeTerm string
+	if searchTerm != "" {
+		likeTerm = "%" + searchTerm + "%"
+		query = query.Where(
+			"rf_spdx_id ILIKE ? OR rf_fullname ILIKE ? OR rf_shortname ILIKE ? OR rf_text ILIKE ?",
+			likeTerm, likeTerm, likeTerm, likeTerm,
+		)
+	}
+
 	sortBy := c.Query("sort_by")
 	orderBy := c.Query("order_by")
 	queryOrderString := ""
@@ -124,7 +136,22 @@ func FilterLicense(c *gin.Context) {
 		queryOrderString += " desc"
 	}
 
-	query.Order(queryOrderString)
+	if searchTerm != "" {
+		// Rank spdx_id matches above fullname matches, above shortname matches, above
+		// text matches, falling back to the requested sort_by/order_by to break ties
+		// within the same rank.
+		rankSQL := "CASE " +
+			"WHEN rf_spdx_id ILIKE ? THEN 1 " +
+			"WHEN rf_fullname ILIKE ? THEN 2 " +
+			"WHEN rf_shortname ILIKE ? THEN 3 " +
+			"WHEN rf_text ILIKE ? THEN 4 " +
+			"ELSE 5 END, " + queryOrderString
+		query = query.Order(clause.OrderBy{
+			Expression: gorm.Expr(rankSQL, likeTerm, likeTerm, likeTerm, likeTerm),
+		})
+	} else {
+		query = query.Order(queryOrderString)
+	}
 
 	_ = utils.PreparePaginateResponse(c, query, &models.LicenseResponse{})
 
@@ -505,98 +532,6 @@ func UpdateLicense(c *gin.Context) {
 
 		return nil
 	})
-}
-
-// SearchInLicense Search for license data based on user-provided search criteria.
-//
-//	@Summary		Search licenses
-//	@Description	Search licenses on different filters and algorithms
-//	@Id				SearchInLicense
-//	@Tags			Licenses
-//	@Accept			json
-//	@Produce		json
-//	@Param			search	body		models.SearchLicense	true	"Search criteria"
-//	@Success		200		{object}	models.LicenseResponse	"Licenses matched"
-//	@Failure		400		{object}	models.LicenseError		"Invalid request"
-//	@Failure		404		{object}	models.LicenseError		"Search algorithm doesn't exist"
-//	@Security		ApiKeyAuth || {}
-//	@Router			/search [post]
-func SearchInLicense(c *gin.Context) {
-	var input models.SearchLicense
-
-	if err := c.ShouldBindJSON(&input); err != nil {
-		er := models.LicenseError{
-			Status:    http.StatusBadRequest,
-			Message:   "invalid json body",
-			Error:     err.Error(),
-			Path:      c.Request.URL.Path,
-			Timestamp: time.Now().Format(time.RFC3339),
-		}
-		c.JSON(http.StatusBadRequest, er)
-		return
-	}
-
-	input.Field = "rf_" + input.Field
-
-	var licenses []models.LicenseDB
-	query := db.DB.Model(&licenses)
-
-	if !db.DB.Migrator().HasColumn(&models.LicenseDB{}, input.Field) {
-		er := models.LicenseError{
-			Status:    http.StatusBadRequest,
-			Message:   fmt.Sprintf("invalid field name '%s'", input.Field),
-			Error:     "field does not exist in the database",
-			Path:      c.Request.URL.Path,
-			Timestamp: time.Now().Format(time.RFC3339),
-		}
-		c.JSON(http.StatusBadRequest, er)
-		return
-	}
-
-	switch input.Search {
-	case "fuzzy":
-		query = query.Where(fmt.Sprintf("%s ILIKE ?", input.Field),
-			fmt.Sprintf("%%%s%%", input.SearchTerm))
-	case "", "full_text_search":
-		query = query.Where(input.Field+" @@ plainto_tsquery(?)", input.SearchTerm)
-	default:
-		er := models.LicenseError{
-			Status:    http.StatusNotFound,
-			Message:   "search algorithm doesn't exist",
-			Error:     "search algorithm with such name doesn't exists",
-			Path:      c.Request.URL.Path,
-			Timestamp: time.Now().Format(time.RFC3339),
-		}
-		c.JSON(http.StatusNotFound, er)
-		return
-	}
-	err := query.Preload("User").Preload("Obligations").Find(&licenses).Error
-	if err != nil {
-		er := models.LicenseError{
-			Status:    http.StatusBadRequest,
-			Message:   "Query failed because of error",
-			Error:     err.Error(),
-			Path:      c.Request.URL.Path,
-			Timestamp: time.Now().Format(time.RFC3339),
-		}
-		c.JSON(http.StatusBadRequest, er)
-		return
-	}
-
-	licensedtos := []models.LicenseResponseDTO{}
-
-	for _, l := range licenses {
-		licensedtos = append(licensedtos, l.ConvertToLicenseResponseDTO())
-	}
-
-	res := models.LicenseResponse{
-		Data:   licensedtos,
-		Status: http.StatusOK,
-		Meta: &models.PaginationMeta{
-			ResourceCount: len(licenses),
-		},
-	}
-	c.JSON(http.StatusOK, res)
 }
 
 // ImportLicenses creates new licenses records via a json file.

--- a/pkg/api/obligations.go
+++ b/pkg/api/obligations.go
@@ -26,17 +26,19 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // GetAllObligation retrieves a list of all obligation records
 //
 //	@Summary		Get all active obligations
-//	@Description	Get all active obligations from the service
+//	@Description	Get all active obligations from the service. The `search` parameter does a fuzzy match against the topic and text fields, with results ranked so topic matches come before text matches.
 //	@Id				GetAllObligation
 //	@Tags			Obligations
 //	@Accept			json
 //	@Produce		json
 //	@Param			active		query		bool	true	"Active obligation only"
+//	@Param			search		query		string	false	"Fuzzy search text matched against topic and text fields (ranked topic > text)"
 //	@Param			page		query		int		false	"Page number"
 //	@Param			limit		query		int		false	"Number of records per page"
 //	@Param			order_by	query		string	false	"Asc or desc ordering"	Enums(asc, desc)	default(asc)
@@ -64,8 +66,16 @@ func GetAllObligation(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, er)
 		return
 	}
+	searchTerm := strings.TrimSpace(c.Query("search"))
+
 	query := db.DB.Model(&models.Obligation{})
 	query.Where(&models.Obligation{Active: &parsedActive})
+
+	var likeTerm string
+	if searchTerm != "" {
+		likeTerm = "%" + searchTerm + "%"
+		query.Where("topic ILIKE ? OR text ILIKE ?", likeTerm, likeTerm)
+	}
 
 	_ = utils.PreparePaginateResponse(c, query, &models.ObligationResponse{})
 
@@ -76,7 +86,19 @@ func GetAllObligation(c *gin.Context) {
 		queryOrderString += " desc"
 	}
 
-	query.Order(queryOrderString)
+	if searchTerm != "" {
+		// Rank topic matches above text matches, falling back to the requested
+		// order_by to break ties within the same rank.
+		rankSQL := "CASE " +
+			"WHEN topic ILIKE ? THEN 1 " +
+			"WHEN text ILIKE ? THEN 2 " +
+			"ELSE 3 END, " + queryOrderString
+		query.Order(clause.OrderBy{
+			Expression: gorm.Expr(rankSQL, likeTerm, likeTerm),
+		})
+	} else {
+		query.Order(queryOrderString)
+	}
 
 	if err = query.Joins("Type").Joins("Classification").Joins("Category").Preload("Licenses").Find(&obligations).Error; err != nil {
 		er := models.LicenseError{

--- a/pkg/db/migrations/000018_gin_trgm_search_indexes.down.sql
+++ b/pkg/db/migrations/000018_gin_trgm_search_indexes.down.sql
@@ -1,0 +1,11 @@
+-- SPDX-FileCopyrightText: 2026 FOSSology contributors
+-- SPDX-License-Identifier: GPL-2.0-only
+
+DROP INDEX IF EXISTS gin_rf_spdx_id_idx;
+DROP INDEX IF EXISTS gin_rf_fullname_idx;
+DROP INDEX IF EXISTS gin_rf_shortname_idx;
+DROP INDEX IF EXISTS gin_rf_text_idx;
+
+-- Restore the original GiST trigram index on rf_text from 000010_pg_trgm_and_index.
+CREATE INDEX IF NOT EXISTS gist_rf_text_idx
+ON license_dbs USING gist (rf_text gist_trgm_ops);

--- a/pkg/db/migrations/000018_gin_trgm_search_indexes.up.sql
+++ b/pkg/db/migrations/000018_gin_trgm_search_indexes.up.sql
@@ -1,0 +1,30 @@
+-- SPDX-FileCopyrightText: 2026 FOSSology contributors
+-- SPDX-License-Identifier: GPL-2.0-only
+
+-- pg_trgm is already enabled by an earlier migration; keep this idempotent.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- GET /licenses?search=... fuzzy-matches rf_spdx_id, rf_fullname, rf_shortname
+-- and rf_text with ILIKE. GIN trigram indexes let the planner use (bitmap)
+-- index scans for those ILIKE predicates instead of a sequential scan across
+-- all rows.
+--
+-- The rf_text column previously only had a GiST trigram index (from
+-- 000010_pg_trgm_and_index), which also supports ILIKE and the pg_trgm `%`
+-- similarity operator used by getSimilarLicenses. It is replaced here with a
+-- GIN index for faster lookups and consistency with the other search-field
+-- indexes; GIN trades slower writes for faster reads, which suits this
+-- read-heavy, low-write reference table.
+DROP INDEX IF EXISTS gist_rf_text_idx;
+
+CREATE INDEX IF NOT EXISTS gin_rf_spdx_id_idx
+ON license_dbs USING gin (rf_spdx_id gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS gin_rf_fullname_idx
+ON license_dbs USING gin (rf_fullname gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS gin_rf_shortname_idx
+ON license_dbs USING gin (rf_shortname gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS gin_rf_text_idx
+ON license_dbs USING gin (rf_text gin_trgm_ops);

--- a/pkg/db/migrations/000019_gin_trgm_obligation_search_indexes.down.sql
+++ b/pkg/db/migrations/000019_gin_trgm_obligation_search_indexes.down.sql
@@ -1,0 +1,9 @@
+-- SPDX-FileCopyrightText: 2026 FOSSology contributors
+-- SPDX-License-Identifier: GPL-2.0-only
+
+DROP INDEX IF EXISTS gin_topic_idx;
+DROP INDEX IF EXISTS gin_text_idx;
+
+-- Restore the original GiST trigram index on text from 000010_pg_trgm_and_index.
+CREATE INDEX IF NOT EXISTS gist_text_idx
+ON obligations USING gist (text gist_trgm_ops);

--- a/pkg/db/migrations/000019_gin_trgm_obligation_search_indexes.up.sql
+++ b/pkg/db/migrations/000019_gin_trgm_obligation_search_indexes.up.sql
@@ -1,0 +1,23 @@
+-- SPDX-FileCopyrightText: 2026 FOSSology contributors
+-- SPDX-License-Identifier: GPL-2.0-only
+
+-- pg_trgm is already enabled by an earlier migration; keep this idempotent.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- GET /obligations?search=... fuzzy-matches topic and text with ILIKE. GIN
+-- trigram indexes let the planner use (bitmap) index scans for those ILIKE
+-- predicates instead of a sequential scan across all rows.
+--
+-- The text column previously only had a GiST trigram index (from
+-- 000010_pg_trgm_and_index), which also supports ILIKE and the pg_trgm `%`
+-- similarity operator used by getSimilarObligations. It is replaced here with
+-- a GIN index for faster lookups and consistency with the new topic index;
+-- GIN trades slower writes for faster reads, which suits this read-heavy,
+-- low-write reference table.
+DROP INDEX IF EXISTS gist_text_idx;
+
+CREATE INDEX IF NOT EXISTS gin_topic_idx
+ON obligations USING gin (topic gin_trgm_ops);
+
+CREATE INDEX IF NOT EXISTS gin_text_idx
+ON obligations USING gin (text gin_trgm_ops);

--- a/pkg/models/types.go
+++ b/pkg/models/types.go
@@ -167,13 +167,6 @@ type UserResponse struct {
 	Meta   *PaginationMeta `json:"paginationmeta"`
 }
 
-// SearchLicense struct represents the input needed to search in a license.
-type SearchLicense struct {
-	Field      string `json:"field" binding:"required" example:"text"`
-	SearchTerm string `json:"search_term" binding:"required" example:"MIT License"`
-	Search     string `json:"search" enums:"fuzzy,full_text_search"`
-}
-
 // Audit struct represents an audit entity with certain attributes and properties
 // It has user id as a foreign key
 type Audit struct {

--- a/tests/licenses_comprehensive_test.go
+++ b/tests/licenses_comprehensive_test.go
@@ -113,6 +113,108 @@ func TestFilterLicense(t *testing.T) {
 		w := makeRequest("GET", "/licenses?sort_by=invalid_field", nil, true)
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
+
+	t.Run("searchRanksSpdxAboveFullnameAboveShortnameAboveText", func(t *testing.T) {
+		spdxMatch := models.LicenseCreateDTO{
+			Shortname: "ZZRANK-SPDX",
+			Fullname:  "Unrelated Full Name Four",
+			Text:      "text body unrelated to the search token",
+			Notes:     ptr("Test notes"),
+			Source:    ptr("test"),
+			SpdxId:    "LicenseRef-ZZRANKTOKEN",
+			Risk:      ptr(int64(1)),
+		}
+		fullnameMatch := models.LicenseCreateDTO{
+			Shortname: "ZZRANK-FULL",
+			Fullname:  "ZzRankToken Special License",
+			Text:      "text body unrelated to the search token",
+			Notes:     ptr("Test notes"),
+			Source:    ptr("test"),
+			SpdxId:    "LicenseRef-ZZRANK-FULL",
+			Risk:      ptr(int64(1)),
+		}
+		shortnameMatch := models.LicenseCreateDTO{
+			Shortname: "ZzRankToken-Short",
+			Fullname:  "Unrelated Full Name Two",
+			Text:      "text body unrelated to the search token",
+			Notes:     ptr("Test notes"),
+			Source:    ptr("test"),
+			SpdxId:    "LicenseRef-ZZRANK-SHORT",
+			Risk:      ptr(int64(1)),
+		}
+		textMatch := models.LicenseCreateDTO{
+			Shortname: "ZZRANK-TEXT",
+			Fullname:  "Unrelated Full Name Three",
+			Text:      "this text body contains ZzRankToken inside it",
+			Notes:     ptr("Test notes"),
+			Source:    ptr("test"),
+			SpdxId:    "LicenseRef-ZZRANK-TEXT",
+			Risk:      ptr(int64(1)),
+		}
+
+		// Create in a shuffled order so a pass here can't be explained by insertion/id order.
+		for _, lic := range []models.LicenseCreateDTO{textMatch, fullnameMatch, spdxMatch, shortnameMatch} {
+			w := makeRequest("POST", "/licenses", lic, true)
+			assert.Equal(t, http.StatusCreated, w.Code)
+		}
+
+		w := makeRequest("GET", "/licenses?search=ZzRankToken", nil, true)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var res models.LicenseResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+			t.Errorf("Error unmarshalling JSON: %v", err)
+			return
+		}
+
+		shortnames := make([]string, 0, len(res.Data))
+		for _, l := range res.Data {
+			shortnames = append(shortnames, l.Shortname)
+		}
+		assert.Equal(t, []string{"ZZRANK-SPDX", "ZZRANK-FULL", "ZzRankToken-Short", "ZZRANK-TEXT"}, shortnames,
+			"spdx_id match should rank above fullname match, above shortname match, above text match")
+	})
+
+	t.Run("searchCombinesWithOtherFiltersUsingAnd", func(t *testing.T) {
+		// The search matches created above are all active, so requiring active=false
+		// alongside the search term must yield no results if search and active are
+		// correctly ANDed (and the OR inside the search clause is parenthesized).
+		w := makeRequest("GET", "/licenses?search=ZzRankToken&active=false", nil, true)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var res models.LicenseResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+			t.Errorf("Error unmarshalling JSON: %v", err)
+			return
+		}
+		assert.Equal(t, 0, len(res.Data))
+	})
+
+	t.Run("searchWithNoMatches", func(t *testing.T) {
+		w := makeRequest("GET", "/licenses?search=ThisTermShouldNotMatchAnyLicenseAtAll", nil, true)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var res models.LicenseResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+			t.Errorf("Error unmarshalling JSON: %v", err)
+			return
+		}
+		assert.Equal(t, 0, len(res.Data))
+	})
+
+	t.Run("searchIsPaginated", func(t *testing.T) {
+		w := makeRequest("GET", "/licenses?search=ZzRankToken&page=1&limit=2", nil, true)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var res models.LicenseResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+			t.Errorf("Error unmarshalling JSON: %v", err)
+			return
+		}
+		assert.Equal(t, 2, len(res.Data))
+		assert.NotNil(t, res.Meta)
+		assert.Equal(t, 4, res.Meta.ResourceCount)
+	})
 }
 
 func TestExportLicenses(t *testing.T) {
@@ -496,71 +598,6 @@ func TestImportLicenses(t *testing.T) {
 		}
 		assert.Equal(t, http.StatusOK, res.Status)
 		assert.GreaterOrEqual(t, len(res.Data), 0)
-	})
-}
-
-func TestSearchInLicense(t *testing.T) {
-	t.Run("searchWithFullText", func(t *testing.T) {
-		searchReq := models.SearchLicense{
-			Field:      "shortname",
-			Search:     "full_text_search",
-			SearchTerm: "MIT",
-		}
-
-		w := makeRequest("POST", "/search", searchReq, true)
-		assert.Equal(t, http.StatusOK, w.Code)
-
-		var res models.LicenseResponse
-		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
-			t.Errorf("Error unmarshalling JSON: %v", err)
-			return
-		}
-		assert.Equal(t, http.StatusOK, res.Status)
-	})
-
-	t.Run("searchWithFuzzy", func(t *testing.T) {
-		searchReq := models.SearchLicense{
-			Field:      "fullname",
-			Search:     "fuzzy",
-			SearchTerm: "MIT",
-		}
-
-		w := makeRequest("POST", "/search", searchReq, true)
-		assert.Equal(t, http.StatusOK, w.Code)
-
-		var res models.LicenseResponse
-		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
-			t.Errorf("Error unmarshalling JSON: %v", err)
-			return
-		}
-		assert.Equal(t, http.StatusOK, res.Status)
-	})
-
-	t.Run("searchWithInvalidField", func(t *testing.T) {
-		searchReq := models.SearchLicense{
-			Field:      "invalid_field",
-			Search:     "full_text_search",
-			SearchTerm: "MIT",
-		}
-
-		w := makeRequest("POST", "/search", searchReq, true)
-		assert.Equal(t, http.StatusBadRequest, w.Code)
-	})
-
-	t.Run("searchWithInvalidAlgorithm", func(t *testing.T) {
-		searchReq := models.SearchLicense{
-			Field:      "shortname",
-			Search:     "invalid_algorithm",
-			SearchTerm: "MIT",
-		}
-
-		w := makeRequest("POST", "/search", searchReq, true)
-		assert.Equal(t, http.StatusNotFound, w.Code)
-	})
-
-	t.Run("searchWithInvalidJSON", func(t *testing.T) {
-		w := makeRequest("POST", "/search", []byte("invalid json"), true)
-		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
 }
 

--- a/tests/obligations_comprehensive_test.go
+++ b/tests/obligations_comprehensive_test.go
@@ -58,6 +58,92 @@ func TestGetAllObligation(t *testing.T) {
 		}
 		assert.Equal(t, http.StatusOK, res.Status)
 	})
+
+	t.Run("searchRanksTopicAboveText", func(t *testing.T) {
+		topicMatch := models.ObligationCreateDTO{
+			Topic:          "ZZObRankToken Topic",
+			Type:           "RIGHT",
+			Text:           "text body unrelated to the search token",
+			Classification: "GREEN",
+			Comment:        ptr("search rank test: topic match"),
+			Active:         ptr(true),
+			TextUpdatable:  ptr(false),
+			Category:       "GENERAL",
+		}
+		textMatch := models.ObligationCreateDTO{
+			Topic:          "Unrelated Topic Name",
+			Type:           "RIGHT",
+			Text:           "this text body contains ZZObRankToken inside it",
+			Classification: "GREEN",
+			Comment:        ptr("search rank test: text match"),
+			Active:         ptr(true),
+			TextUpdatable:  ptr(false),
+			Category:       "GENERAL",
+		}
+
+		// Create in a shuffled order so a pass here can't be explained by insertion/id order.
+		for _, ob := range []models.ObligationCreateDTO{textMatch, topicMatch} {
+			w := makeRequest("POST", "/obligations", ob, true)
+			assert.Equal(t, http.StatusCreated, w.Code)
+		}
+
+		w := makeRequest("GET", "/obligations?search=ZZObRankToken", nil, true)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var res models.ObligationResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+			t.Errorf("Error unmarshalling JSON: %v", err)
+			return
+		}
+
+		topics := make([]string, 0, len(res.Data))
+		for _, o := range res.Data {
+			topics = append(topics, o.Topic)
+		}
+		assert.Equal(t, []string{"ZZObRankToken Topic", "Unrelated Topic Name"}, topics,
+			"topic match should rank above text match")
+	})
+
+	t.Run("searchCombinesWithOtherFiltersUsingAnd", func(t *testing.T) {
+		// The search matches created above are all active, so requiring active=false
+		// alongside the search term must yield no results if search and active are
+		// correctly ANDed (and the OR inside the search clause is parenthesized).
+		w := makeRequest("GET", "/obligations?search=ZZObRankToken&active=false", nil, true)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var res models.ObligationResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+			t.Errorf("Error unmarshalling JSON: %v", err)
+			return
+		}
+		assert.Equal(t, 0, len(res.Data))
+	})
+
+	t.Run("searchWithNoMatches", func(t *testing.T) {
+		w := makeRequest("GET", "/obligations?search=ThisTermShouldNotMatchAnyObligationAtAll", nil, true)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var res models.ObligationResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+			t.Errorf("Error unmarshalling JSON: %v", err)
+			return
+		}
+		assert.Equal(t, 0, len(res.Data))
+	})
+
+	t.Run("searchIsPaginated", func(t *testing.T) {
+		w := makeRequest("GET", "/obligations?search=ZZObRankToken&page=1&limit=1", nil, true)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var res models.ObligationResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+			t.Errorf("Error unmarshalling JSON: %v", err)
+			return
+		}
+		assert.Equal(t, 1, len(res.Data))
+		assert.NotNil(t, res.Meta)
+		assert.Equal(t, 2, res.Meta.ResourceCount)
+	})
 }
 
 func TestGetObligation(t *testing.T) {


### PR DESCRIPTION
## Changes

- Merge the separate `POST /search` endpoint into `GET /licenses` via a new `search` query parameter, fuzzy-matching `spdx_id`, `fullname`, `shortname` and `text` fields, with results ranked `spdx_id > fullname > shortname > text`.
- Add the same capability to `GET /obligations` via `search`, matching `topic` and `text` fields, ranked `topic > text`.
- Remove the now-redundant `SearchInLicense` handler, `/search` route, and `SearchLicense` DTO.
- Add GIN trigram indexes on the searched columns (migrations `000017`, `000019`), replacing the prior GiST indexes on `rf_text`/`text`, for fast `ILIKE` lookups at scale.
- Update Swagger/OpenAPI docs to reflect the new `search` parameter and the removed `/search` path.

- Closes #220

## Submitter Checklist

- [x] Includes tests (if there is a feature changed/added)
- [x] Includes docs ( if changes are user facing)
- [x] I have tested my changes locally.
