### PR TITLE
Add search_term filters for licenses and obligations

### DIFF
--- a/pkg/api/licenses.go
+++ b/pkg/api/licenses.go
@@ -40,6 +40,7 @@ import (
 //	@Accept			json
 //	@Produce		json
 //	@Param			spdxid		query		string					false	"SPDX ID of the license"
+//	@Param			search_term	query		string					false	"Search full name, short name, text, or SPDX expression"
 //	@Param			active		query		bool					false	"Active license only"
 //	@Param			osiapproved	query		bool					false	"OSI Approved flag status of license"
 //	@Param			copyleft	query		bool					false	"Copyleft flag status of license"
@@ -54,6 +55,7 @@ import (
 //	@Router			/licenses [get]
 func FilterLicense(c *gin.Context) {
 	SpdxId := c.Query("spdxid")
+	searchTerm := c.Query("search_term")
 	active := c.Query("active")
 	OSIapproved := c.Query("osiapproved")
 	copyleft := c.Query("copyleft")
@@ -105,6 +107,14 @@ func FilterLicense(c *gin.Context) {
 
 	if SpdxId != "" {
 		query = query.Where(models.LicenseDB{SpdxId: &SpdxId})
+	}
+
+	if searchTerm != "" {
+		searchPattern := "%" + searchTerm + "%"
+		query = query.Where(
+			"(rf_fullname ILIKE ? OR rf_shortname ILIKE ? OR rf_text ILIKE ? OR rf_spdx_id ILIKE ?)",
+			searchPattern, searchPattern, searchPattern, searchPattern,
+		)
 	}
 
 	for externalRefKey, externalRefValue := range externalRefData {

--- a/pkg/api/obligations.go
+++ b/pkg/api/obligations.go
@@ -37,6 +37,7 @@ import (
 //	@Accept			json
 //	@Produce		json
 //	@Param			active		query		bool	true	"Active obligation only"
+//	@Param			search_term	query		string	false	"Search obligation topic or text"
 //	@Param			page		query		int		false	"Page number"
 //	@Param			limit		query		int		false	"Number of records per page"
 //	@Param			order_by	query		string	false	"Asc or desc ordering"	Enums(asc, desc)	default(asc)
@@ -48,6 +49,7 @@ import (
 func GetAllObligation(c *gin.Context) {
 	var obligations []models.Obligation
 	active := c.Query("active")
+	searchTerm := c.Query("search_term")
 	if active == "" {
 		active = "true"
 	}
@@ -66,6 +68,10 @@ func GetAllObligation(c *gin.Context) {
 	}
 	query := db.DB.Model(&models.Obligation{})
 	query.Where(&models.Obligation{Active: &parsedActive})
+	if searchTerm != "" {
+		searchPattern := "%" + searchTerm + "%"
+		query = query.Where("(topic ILIKE ? OR text ILIKE ?)", searchPattern, searchPattern)
+	}
 
 	_ = utils.PreparePaginateResponse(c, query, &models.ObligationResponse{})
 

--- a/tests/licenses_comprehensive_test.go
+++ b/tests/licenses_comprehensive_test.go
@@ -84,6 +84,19 @@ func TestFilterLicense(t *testing.T) {
 		}
 	})
 
+	t.Run("filterWithSearchTerm", func(t *testing.T) {
+		w := makeRequest("GET", "/licenses?search_term=filter%20spdx", nil, true)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var res models.LicenseResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+			t.Errorf("Error unmarshalling JSON: %v", err)
+			return
+		}
+		assert.NotEmpty(t, res.Data)
+		assert.Equal(t, "TEST-FILTER-SPDX", res.Data[0].Shortname)
+	})
+
 	t.Run("filterWithPagination", func(t *testing.T) {
 		w := makeRequest("GET", "/licenses?page=1&limit=5", nil, true)
 		assert.Equal(t, http.StatusOK, w.Code)

--- a/tests/obligations_comprehensive_test.go
+++ b/tests/obligations_comprehensive_test.go
@@ -58,6 +58,31 @@ func TestGetAllObligation(t *testing.T) {
 		}
 		assert.Equal(t, http.StatusOK, res.Status)
 	})
+
+	t.Run("searchObligationsByTopic", func(t *testing.T) {
+		dto := models.ObligationCreateDTO{
+			Topic:          "searchable obligation",
+			Type:           "RIGHT",
+			Text:           "searchable obligation text",
+			Classification: "GREEN",
+			Category:       "GENERAL",
+			Active:         ptr(true),
+			TextUpdatable:  ptr(false),
+		}
+		createW := makeRequest("POST", "/obligations", dto, true)
+		assert.Equal(t, http.StatusCreated, createW.Code)
+
+		w := makeRequest("GET", "/obligations?search_term=searchable%20obligation", nil, true)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var res models.ObligationResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &res); err != nil {
+			t.Errorf("Error unmarshalling JSON: %v", err)
+			return
+		}
+		assert.NotEmpty(t, res.Data)
+		assert.Equal(t, dto.Topic, res.Data[0].Topic)
+	})
 }
 
 func TestGetObligation(t *testing.T) {


### PR DESCRIPTION
## Changes

- Add an optional `search_term` query parameter to `GET /licenses`, matching full name, short name, license text, or SPDX ID with a parameterized case-insensitive search.
- Add the same optional `search_term` capability to `GET /obligations`, matching obligation topic or text.
- Add comprehensive API coverage for both filters and document the new Swagger parameters.
- Fixes #220

## Submitter Checklist

- [x] Includes tests (if there is a feature changed/added)
- [x] Includes docs (if changes are user facing) — Swagger annotations document both query parameters.
- [ ] I have tested my changes locally — the environment does not include a Go toolchain; `git diff --check` and source-level review passed.

## References

- `git diff --check`
- The search values are passed as bound query parameters rather than interpolated into SQL.
